### PR TITLE
"Scroll to element" functionality broken when adding a listing

### DIFF
--- a/assets/js/global-add-listing.js
+++ b/assets/js/global-add-listing.js
@@ -641,7 +641,7 @@ $('body').on('submit', formID, function (e) {
               msg: uploader.uploaders_data['error_msg']
             };
             error_count++;
-            UIkit2.Utils.scrollToElement('#' + uploader.uploaders_data['element_id']);
+            UIkit2.Utils.scrollToElement($('#' + uploader.uploaders_data['element_id']));
           }
         }
       }

--- a/assets/js/global-add-listing.js
+++ b/assets/js/global-add-listing.js
@@ -641,7 +641,7 @@ $('body').on('submit', formID, function (e) {
               msg: uploader.uploaders_data['error_msg']
             };
             error_count++;
-            scrollToEl('#' + uploader.uploaders_data['element_id']);
+            UIkit2.Utils.scrollToElement('#' + uploader.uploaders_data['element_id']);
           }
         }
       }

--- a/assets/src/js/global/add-listing.js
+++ b/assets/src/js/global/add-listing.js
@@ -511,7 +511,7 @@ $('body').on('submit', formID, function (e) {
                     $('.directorist-form-submit__btn').removeClass('atbd_loading');
                     err_log.listing_gallery = { msg: uploader.uploaders_data['error_msg'] };
                     error_count++;
-                    scrollToEl('#' + uploader.uploaders_data['element_id']);
+                    scrollToElement('#' + uploader.uploaders_data['element_id']);
                 }
             }
         }

--- a/assets/src/js/global/add-listing.js
+++ b/assets/src/js/global/add-listing.js
@@ -511,7 +511,7 @@ $('body').on('submit', formID, function (e) {
                     $('.directorist-form-submit__btn').removeClass('atbd_loading');
                     err_log.listing_gallery = { msg: uploader.uploaders_data['error_msg'] };
                     error_count++;
-                    scrollToElement('#' + uploader.uploaders_data['element_id']);
+                    UIkit2.Utils.scrollToElement($('#' + uploader.uploaders_data['element_id']));
                 }
             }
         }

--- a/includes/classes/class-enqueue-assets.php
+++ b/includes/classes/class-enqueue-assets.php
@@ -529,7 +529,7 @@ class Enqueue_Assets {
 			'ver'            => self::$script_version,
 			'group'          => 'public',                         // public || admin  || global
 			'section'        => '',
-			'enable'         => false,
+			'enable'         => true,
 			'fource_enqueue' => is_singular( ATBDP_POST_TYPE ),
 		];
 


### PR DESCRIPTION
i.e. `scrollToEl` should be `scrollToElement`

This occurs when adding a listing via the guest add listing page. when an image (that is large enough to trigger a validation error) is specified in the "Images & Video" section...

![image](https://user-images.githubusercontent.com/402597/123456853-2ce6ca80-d598-11eb-8c2e-692aafc8fdf3.png)
