### PR TITLE
DOM data not parsed correctly when loading map

### DIFF
--- a/assets/js/global-add-listing-gmap-custom-script.js
+++ b/assets/js/global-add-listing-gmap-custom-script.js
@@ -324,18 +324,18 @@ function get_dom_data(key) {
     return '';
   }
 
-  var pattern = new RegExp("(<!-- directorist-dom-data::" + key + "\\s)(.+)(\\s-->)");
+  var pattern = new RegExp("<!-- directorist-dom-data::" + key + "(.*?)-->");
   var terget_content = pattern.exec(dom_content);
 
   if (!terget_content) {
     return '';
   }
 
-  if (typeof terget_content[2] === 'undefined') {
+  if (typeof terget_content[1] === 'undefined') {
     return '';
   }
 
-  var dom_data = JSON.parse(terget_content[2]);
+  var dom_data = JSON.parse(terget_content[1]);
 
   if (!dom_data) {
     return '';

--- a/assets/js/global-add-listing-openstreet-map-custom-script.js
+++ b/assets/js/global-add-listing-openstreet-map-custom-script.js
@@ -259,18 +259,18 @@ function get_dom_data(key) {
     return '';
   }
 
-  var pattern = new RegExp("(<!-- directorist-dom-data::" + key + "\\s)(.+)(\\s-->)");
+  var pattern = new RegExp("<!-- directorist-dom-data::" + key + "(.*?)-->");
   var terget_content = pattern.exec(dom_content);
 
   if (!terget_content) {
     return '';
   }
 
-  if (typeof terget_content[2] === 'undefined') {
+  if (typeof terget_content[1] === 'undefined') {
     return '';
   }
 
-  var dom_data = JSON.parse(terget_content[2]);
+  var dom_data = JSON.parse(terget_content[1]);
 
   if (!dom_data) {
     return '';

--- a/assets/js/global-directorist-plupload.js
+++ b/assets/js/global-directorist-plupload.js
@@ -544,18 +544,18 @@ function get_dom_data(key) {
     return '';
   }
 
-  var pattern = new RegExp("(<!-- directorist-dom-data::" + key + "\\s)(.+)(\\s-->)");
+  var pattern = new RegExp("<!-- directorist-dom-data::" + key + "(.*?)-->");
   var terget_content = pattern.exec(dom_content);
 
   if (!terget_content) {
     return '';
   }
 
-  if (typeof terget_content[2] === 'undefined') {
+  if (typeof terget_content[1] === 'undefined') {
     return '';
   }
 
-  var dom_data = JSON.parse(terget_content[2]);
+  var dom_data = JSON.parse(terget_content[1]);
 
   if (!dom_data) {
     return '';

--- a/assets/js/global-load-osm-map.js
+++ b/assets/js/global-load-osm-map.js
@@ -156,18 +156,18 @@ function get_dom_data(key) {
     return '';
   }
 
-  var pattern = new RegExp("(<!-- directorist-dom-data::" + key + "\\s)(.+)(\\s-->)");
+  var pattern = new RegExp("<!-- directorist-dom-data::" + key + "(.*?)-->");
   var terget_content = pattern.exec(dom_content);
 
   if (!terget_content) {
     return '';
   }
 
-  if (typeof terget_content[2] === 'undefined') {
+  if (typeof terget_content[1] === 'undefined') {
     return '';
   }
 
-  var dom_data = JSON.parse(terget_content[2]);
+  var dom_data = JSON.parse(terget_content[1]);
 
   if (!dom_data) {
     return '';

--- a/assets/js/global-map-view.js
+++ b/assets/js/global-map-view.js
@@ -403,18 +403,18 @@ function get_dom_data(key) {
     return '';
   }
 
-  var pattern = new RegExp("(<!-- directorist-dom-data::" + key + "\\s)(.+)(\\s-->)");
+  var pattern = new RegExp("<!-- directorist-dom-data::" + key + "(.*?)-->");
   var terget_content = pattern.exec(dom_content);
 
   if (!terget_content) {
     return '';
   }
 
-  if (typeof terget_content[2] === 'undefined') {
+  if (typeof terget_content[1] === 'undefined') {
     return '';
   }
 
-  var dom_data = JSON.parse(terget_content[2]);
+  var dom_data = JSON.parse(terget_content[1]);
 
   if (!dom_data) {
     return '';

--- a/assets/src/js/lib/helper.js
+++ b/assets/src/js/lib/helper.js
@@ -3,13 +3,13 @@ function get_dom_data ( key ) {
 
     if ( ! dom_content.length ) { return ''; }
 
-    var pattern = new RegExp("(<!-- directorist-dom-data::" + key + "\\s)(.+)(\\s-->)");
+    var pattern = new RegExp("<!-- directorist-dom-data::" + key + "(.*?)-->");
     var terget_content = pattern.exec( dom_content );
 
     if ( ! terget_content ) { return ''; }
-    if ( typeof terget_content[2] === 'undefined' ) { return ''; }
-    
-    var dom_data = JSON.parse( terget_content[2] );
+    if ( typeof terget_content[1] === 'undefined' ) { return ''; }
+
+    var dom_data = JSON.parse( terget_content[1] );
 
     if ( ! dom_data ) { return ''; }
 

--- a/assets/vendor-js/openstreet-map/subGroup-markercluster-controlLayers-realworld.388.js
+++ b/assets/vendor-js/openstreet-map/subGroup-markercluster-controlLayers-realworld.388.js
@@ -7,13 +7,13 @@ function get_dom_data ( key ) {
 
     if ( ! dom_content.length ) { return ''; }
 
-    var pattern = new RegExp("(<!-- directorist-dom-data::" + key + "\\s)(.+)(\\s-->)");
+    var pattern = new RegExp("<!-- directorist-dom-data::" + key + "(.*?)-->");
     var terget_content = pattern.exec( dom_content );
 
     if ( ! terget_content ) { return ''; }
-    if ( typeof terget_content[2] === 'undefined' ) { return ''; }
-    
-    var dom_data = JSON.parse( terget_content[2] );
+    if ( typeof terget_content[1] === 'undefined' ) { return ''; }
+
+    var dom_data = JSON.parse( terget_content[1] );
 
     if ( ! dom_data ) { return ''; }
 


### PR DESCRIPTION
The old regex doesn't appear to work as intended. It captures multiple HTML comments blocks, as seen in this example:
https://rubular.com/r/0bRhgODRI0IMOk

The new regex properly picks out comment blocks:
https://rubular.com/r/SCaFKAMvMQK2O2
