### PR TITLE
fix issue with polylang rewrite roles

### DIFF
--- a/includes/classes/class-shortcode.php
+++ b/includes/classes/class-shortcode.php
@@ -132,7 +132,7 @@ class ATBDP_Shortcode {
 
 	public function category_archive( $atts ) {
 		$atts             = !empty( $atts ) ? $atts : array();
-		$category_slug    = get_query_var('atbdp_category');
+		$category_slug    = !empty( $_GET['category'] ) ? $_GET['category'] : get_query_var('atbdp_category');
 		$atts['category'] = sanitize_title_for_query( $category_slug );
 		
 		$atts[ 'shortcode' ] = 'directorist_category';
@@ -142,7 +142,7 @@ class ATBDP_Shortcode {
 
 	public function tag_archive( $atts ) {
 		$atts        = !empty( $atts ) ? $atts : array();
-		$tag_slug    = get_query_var('atbdp_tag');
+		$tag_slug    = !empty( $_GET['tag'] ) ? $_GET['tag'] : get_query_var('atbdp_tag');
 		$atts['tag'] = sanitize_title_for_query( $tag_slug );
 		
 		$atts[ 'shortcode' ] = 'directorist_tag';
@@ -152,7 +152,7 @@ class ATBDP_Shortcode {
 
 	public function location_archive( $atts ) {
 		$atts             = !empty( $atts ) ? $atts : array();
-		$location_slug    = get_query_var('atbdp_location');
+		$location_slug    = !empty( $_GET['location'] ) ? $_GET['location'] : get_query_var('atbdp_location');
 		$atts['location'] = sanitize_title_for_query( $location_slug );
 
 		$atts[ 'shortcode' ] = 'directorist_location';


### PR DESCRIPTION
User issue: Polylang categories and locations do not work properly, an issue for 2 years now, apart from that the Directorist is polylang compatible.

Issue found when someone change language https://prnt.sc/1xwlbjm

URL : https://superclassics.eu/language/nl/single-catogery/?category=abarth