### PR TITLE
Fix an issue with user not able to select address if there's no map added on the add listing form

### DIFF
--- a/assets/js/global-add-listing-openstreet-map-custom-script.js
+++ b/assets/js/global-add-listing-openstreet-map-custom-script.js
@@ -182,7 +182,9 @@ __webpack_require__.r(__webpack_exports__);
         lon = loc_manual_lng;
     mapLeaflet(lat, lon);
     $('body').on('click', '.directorist-form-address-field .address_result ul li a', function (event) {
-      document.getElementById('osm').innerHTML = "<div id='gmap'></div>";
+      if(document.getElementById('osm')) {
+        document.getElementById('osm').innerHTML = "<div id='gmap'></div>";
+      }
       event.preventDefault();
       var text = $(this).text(),
           lat = $(this).data('lat'),


### PR DESCRIPTION
Fix an issue with the user not being able to select address if there's no map added on the add listing form
https://www.loom.com/share/47a975740e40404e8c6a562d9cd5bc4c