### PR TITLE
Fixed an issue with the  Author Profile page  where usernames with spaces was showing the profile of currently logged-in user details

### DIFF
--- a/includes/model/ListingAuthor.php
+++ b/includes/model/ListingAuthor.php
@@ -51,6 +51,7 @@ class Directorist_Listing_Author {
 
 	// extract_user_id
 	public function extract_user_id( $user_id = '' ) {
+		$user_id = urldecode($user_id); //decode the URL to remove encoded spaces, special characters
 		$extracted_user_id = ( is_numeric( $user_id ) ) ? $user_id : get_current_user_id();
 
 		if ( is_string( $user_id ) && ! empty( $user_id ) ) {


### PR DESCRIPTION
Fixed an issue with the  Author Profile page  where usernames with spaces were showing the profile of currently logged-in user details
https://www.loom.com/share/94ae85dcf86446efac9f2ad4a0ed6357