### PR TITLE
Selected listings query with instant search

### DIFF
--- a/includes/classes/class-ajax-handler.php
+++ b/includes/classes/class-ajax-handler.php
@@ -108,16 +108,27 @@ if (!class_exists('ATBDP_Ajax_Handler')) :
             add_action('wp_ajax_directorist_author_pagination', array($this, 'author_pagination'));
             add_action('wp_ajax_nopriv_directorist_author_pagination', array($this, 'author_pagination'));
 
-            //instant search 
+            //instant search
             add_action('wp_ajax_directorist_instant_search', array( $this, 'instant_search' ) );
             add_action('wp_ajax_nopriv_directorist_instant_search', array( $this, 'instant_search' ) );
         }
 
         public function instant_search() {
-            if ( wp_verify_nonce( $_POST['_nonce'], 'bdas_ajax_nonce' ) ) {
+			$nonce = ! empty( $_POST['_nonce'] ) ? wp_unslash( $_POST['_nonce'] ) : '';
 
-                $data_atts = ! empty( $_POST['data_atts'] ) ? $_POST['data_atts'] : null;
-                $listings = new Directorist\Directorist_Listings( $data_atts, 'search_result' );
+            if ( wp_verify_nonce( $nonce, 'bdas_ajax_nonce' ) ) {
+				$args = array();
+
+				if ( ! empty( $_POST['data_atts'] ) ) {
+					$args = (array) wp_unslash( $_POST['data_atts'] );
+				}
+
+				if ( ! empty( $args['ids'] ) && ! isset( $_REQUEST['ids'] ) ) {
+					$_REQUEST['ids'] = $args['ids'];
+					$_POST['ids']    = $_REQUEST['ids'];
+				}
+
+                $listings = new Directorist\Directorist_Listings( $args, 'search_result' );
                 $count = $listings->query_results->total;
                 ob_start();
                 echo $listings->archive_view_template();
@@ -131,14 +142,14 @@ if (!class_exists('ATBDP_Ajax_Handler')) :
                 echo $listings->archive_view_template();
                 $view_as = ob_get_clean();
 
-                wp_send_json( 
-                    array( 
+                wp_send_json(
+                    array(
                         'search_result'  => $search_value,
                         'directory_type' => $directory_type_result,
                         'view_as'        => $view_as,
                         'count'          => $count
                     )
-                 );
+				);
             }
         }
 

--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -127,7 +127,7 @@ class Directorist_Listings {
 
 		$this->prepare_atts_data();
 		$this->prepare_data();
-		
+
 		if ( $query_args ) {
 			$this->query_args = $query_args;
 		}
@@ -755,6 +755,11 @@ class Directorist_Listings {
 			$args['no_found_rows'] = true;
 		}
 
+		if ( ! empty( $_REQUEST['ids'] ) ) {
+			$args['post__in'] = wp_parse_id_list( $_REQUEST['ids'] );
+			$this->ids = $args['post__in'];
+		}
+
 		if ( ! empty( $_REQUEST['q'] ) ) {
 			$args['s'] = sanitize_text_field( $_REQUEST['q'] );
 		}
@@ -946,7 +951,7 @@ class Directorist_Listings {
 				'compare' => 'LIKE'
 			);
 		}
-		
+
 		if ( 'address' == $this->radius_search_based_on && ! empty( $_REQUEST['miles'] ) && ! empty( $_REQUEST['cityLat'] ) && ! empty( $_REQUEST['cityLng'] ) ) {
 			$args['atbdp_geo_query'] = array(
 				'lat_field' => '_manual_lat',
@@ -1718,7 +1723,7 @@ class Directorist_Listings {
 
 			return array_unique( $classes );
 		}
-		
+
 		public function data_atts() {
 			// Separates class names with a single space, collates class names for wrapper tag element.
 			echo 'data-atts="' . esc_attr( json_encode( $this->atts ) ) . '"';


### PR DESCRIPTION
When the instant search is enabled and some specific listings ids are passed to all listings shortcode then the ajax query doesn't work on the selected listings instead it loads all the listings.