### PR TITLE
Added a new default image size option for all-listings page

### DIFF
--- a/assets/sample-data/directory/directory-settings.json
+++ b/assets/sample-data/directory/directory-settings.json
@@ -115,7 +115,7 @@
     "all_listing_columns": "3",
     "order_listing_by": "date",
     "sort_listing_by": "desc",
-    "preview_image_quality": "large",
+    "preview_image_quality": "default",
     "way_to_show_preview": "cover",
     "crop_width": "350",
     "crop_height": "260",

--- a/assets/sample-data/directory/directory-settings.json
+++ b/assets/sample-data/directory/directory-settings.json
@@ -115,7 +115,7 @@
     "all_listing_columns": "3",
     "order_listing_by": "date",
     "sort_listing_by": "desc",
-    "preview_image_quality": "default",
+    "preview_image_quality": "directorist_preview",
     "way_to_show_preview": "cover",
     "crop_width": "350",
     "crop_height": "260",

--- a/directorist-base.php
+++ b/directorist-base.php
@@ -180,6 +180,7 @@ final class Directorist_Base
 			add_action('plugins_loaded', array(self::$instance, 'load_textdomain'));
 			add_action('plugins_loaded', array(self::$instance, 'add_polylang_swicher_support') );
 			add_action('widgets_init', array(self::$instance, 'register_widgets'));
+			add_action('after_setup_theme', array(self::$instance, 'add_image_sizes'));
 
 			add_action( 'template_redirect', [ self::$instance, 'check_single_listing_page_restrictions' ] );
 			add_action( 'atbdp_show_flush_messages', [ self::$instance, 'show_flush_messages' ] );
@@ -533,6 +534,15 @@ final class Directorist_Base
 				'before_title' => '<div class="atbd_widget_title"><h4>',
 				'after_title' => '</h4></div>',
 			));
+		}
+	}
+
+	public function add_image_sizes() {
+		$current_preview_size = get_directorist_option( 'preview_image_quality', 'large' );
+
+		if ( $current_preview_size == 'default' ) {
+			$preview_size = directorist_default_preview_size();
+			add_image_size( 'directorist_preview', $preview_size['width'], $preview_size['height'], $preview_size['crop'] );
 		}
 	}
 

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -1849,7 +1849,7 @@ Please remember that your order may be canceled if you do not make your payment 
                     'options' => [
                         [
                             'value' => 'directorist_preview',
-                            'label' => sprintf( __( 'Default', 'directorist' ), $default_preview_size_text ),
+                            'label' => __( 'Default', 'directorist' ),
                         ],
                         [
                             'value' => 'medium',
@@ -1864,7 +1864,7 @@ Please remember that your order may be canceled if you do not make your payment 
                             'label' => __('Full', 'directorist'),
                         ],
                     ],
-					'description' => sprintf( __( 'Default: %s.<br/>If you change this option, please regenerate all thumbnails using <a href="%s" target="__blank">this</a> plugin. Otherwise it may not work properly.', 'directorist' ), $default_preview_size_text, 'https://wordpress.org/plugins/regenerate-thumbnails/' ),
+					'description' => sprintf( __( 'Default: %s.<br/>If you change this option, please regenerate all thumbnails using <a href="%s" target="_blank">this</a> plugin. Otherwise it may not work properly.', 'directorist' ), $default_preview_size_text, 'https://wordpress.org/plugins/regenerate-thumbnails/' ),
                 ],
                 'way_to_show_preview' => [
                     'label' => __('Image Size', 'directorist'),

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -1849,7 +1849,7 @@ Please remember that your order may be canceled if you do not make your payment 
                     'options' => [
                         [
                             'value' => 'directorist_preview',
-                            'label' => sprintf( __( 'Default (%s)', 'directorist' ), $default_preview_size_text ),
+                            'label' => sprintf( __( 'Default', 'directorist' ), $default_preview_size_text ),
                         ],
                         [
                             'value' => 'medium',
@@ -1864,7 +1864,7 @@ Please remember that your order may be canceled if you do not make your payment 
                             'label' => __('Full', 'directorist'),
                         ],
                     ],
-					'description' => sprintf( __( 'If you change this option, please regenerate all thumbnails using <a href="%s" target="__blank">this</a> plugin. Otherwise it may not work properly.', 'directorist' ), 'https://wordpress.org/plugins/regenerate-thumbnails/' ),
+					'description' => sprintf( __( 'Default: %s.<br/>If you change this option, please regenerate all thumbnails using <a href="%s" target="__blank">this</a> plugin. Otherwise it may not work properly.', 'directorist' ), $default_preview_size_text, 'https://wordpress.org/plugins/regenerate-thumbnails/' ),
                 ],
                 'way_to_show_preview' => [
                     'label' => __('Image Size', 'directorist'),

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -478,6 +478,9 @@ Please remember that your order may be canceled if you do not make your payment 
         $bank_payment_desc = __('You can make your payment directly to our bank account using this gateway. Please use your ORDER ID as a reference when making the payment. We will complete your order as soon as your deposit is cleared in our bank.', 'directorist');
         $pricing_plan = '<a style="color: red" href="https://directorist.com/product/directorist-pricing-plans" target="_blank">Pricing Plans</a>';
 
+		$default_size = directorist_default_preview_size();
+		$default_preview_size_text = $default_size['width'].'x'.$default_size['height'].' px';
+
             $this->fields = apply_filters('atbdp_listing_type_settings_field_list', [
 
                 'enable_monetization' => [
@@ -1845,6 +1848,10 @@ Please remember that your order may be canceled if you do not make your payment 
                     'value' => 'large',
                     'options' => [
                         [
+                            'value' => 'directorist_preview',
+                            'label' => sprintf( __( 'Default (%s)', 'directorist' ), $default_preview_size_text ),
+                        ],
+                        [
                             'value' => 'medium',
                             'label' => __('Medium', 'directorist'),
                         ],
@@ -1857,6 +1864,7 @@ Please remember that your order may be canceled if you do not make your payment 
                             'label' => __('Full', 'directorist'),
                         ],
                     ],
+					'description' => sprintf( __( 'If you change this option, please regenerate all thumbnails using <a href="%s" target="__blank">this</a> plugin. Otherwise it may not work properly.', 'directorist' ), 'https://wordpress.org/plugins/regenerate-thumbnails/' ),
                 ],
                 'way_to_show_preview' => [
                     'label' => __('Image Size', 'directorist'),

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4043,3 +4043,13 @@ function directorist_esc_json( $json, $html = false ) {
 		true                               // Double escape entities: `&amp;` -> `&amp;amp;`.
 	);
 }
+
+function directorist_default_preview_size() {
+	return apply_filters(
+		'directorist_default_preview_size', array(
+			'width'  => 640,
+			'height' => 360,
+			'crop'   => true,
+		)
+	);
+}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4044,6 +4044,15 @@ function directorist_esc_json( $json, $html = false ) {
 	);
 }
 
+/**
+ * This image size will be used as the default value of preview image. It can be seen in action
+ * on all-listing page's grid view.
+ *
+ * Custom image size "directorist_preview" is generated based on this size.
+ *
+ * @since 7.4.2
+ * @return array Image size data.
+ */
 function directorist_default_preview_size() {
 	return apply_filters(
 		'directorist_default_preview_size', array(


### PR DESCRIPTION
Screenshot: https://prnt.sc/qmhvjKmF9K-R

It'll improve page load time on all-listings page. Improvement example: https://prnt.sc/CnmppY2UO5R2