### PR TITLE
Filter hook added in announcement user query

### DIFF
--- a/includes/classes/class-announcement.php
+++ b/includes/classes/class-announcement.php
@@ -403,7 +403,7 @@ if ( ! class_exists( 'ATBDP_Announcement' ) ) :
 					array(
 						'role__not_in' => 'Administrator',   // Administrator | Subscriber
 						'fields'       => 'user_email',
-						'number'       => apply_filters( 'directorist_announcement_user_query_num', '' ),
+						'number'       => apply_filters( 'directorist_announcement_user_query_num', 1000 ),
 					)
 				);
 

--- a/includes/classes/class-announcement.php
+++ b/includes/classes/class-announcement.php
@@ -403,6 +403,7 @@ if ( ! class_exists( 'ATBDP_Announcement' ) ) :
 					array(
 						'role__not_in' => 'Administrator',   // Administrator | Subscriber
 						'fields'       => 'user_email',
+						'number'       => apply_filters( 'directorist_announcement_user_query_num', '' ),
 					)
 				);
 

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -134,7 +134,7 @@ if ( ! class_exists('ATBDP_Settings_Panel') ) {
 			$users = get_users(
 				array(
 					'role__not_in' => 'Administrator',   // Administrator | Subscriber
-					'number'       => apply_filters( 'directorist_announcement_user_query_num', '' ),
+					'number'       => apply_filters( 'directorist_announcement_user_query_num', 1000 ),
 				)
 			);
             $recipient = [];

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -131,7 +131,12 @@ if ( ! class_exists('ATBDP_Settings_Panel') ) {
                 'data'                       => [],
             ];
 
-            $users = get_users([ 'role__not_in' => 'Administrator' ]); // Administrator | Subscriber
+			$users = get_users(
+				array(
+					'role__not_in' => 'Administrator',   // Administrator | Subscriber
+					'number'       => apply_filters( 'directorist_announcement_user_query_num', '' ),
+				)
+			);
             $recipient = [];
 
             if ( ! empty( $users ) ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Limit is 1000 now.

**Side effects for existing users:** Now announcement notice/emails will not be sent to more than 1000 users unless user modify the hook.

To change this as unlimited using hook:

`
add_filter( 'directorist_announcement_user_query_num', function() {
	return -1;
} );
`

## Any linked issues
Temporary solution for #1229

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
