### PR TITLE
wrong permalink generated when multi directory is enabled

### DIFF
--- a/includes/model/ListingTaxonomy.php
+++ b/includes/model/ListingTaxonomy.php
@@ -257,8 +257,9 @@ class Directorist_Listing_Taxonomy {
 				if( ! empty( $_GET['directory_type'] ) ) {
 					$directory_type = sanitize_text_field( wp_unslash( $_GET['directory_type'] ) );
 				} else {
-					$current = get_term_by( 'id', $this->current_listing_type, ATBDP_TYPE );
-					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : ( ! is_wp_error( $current ) ? $current->slug : '' );
+					$current_type = get_term( $this->current_listing_type, ATBDP_TYPE );
+					$current_directory_type_slug = ! empty( $current_type ) && ! is_wp_error( $current_type ) ? $current_type->slug : '';
+					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : $current_directory_type_slug;
 				}
 
 				$permalink = ( $this->type == 'category' ) ? ATBDP_Permalink::atbdp_get_category_page( $term, $directory_type ) : ATBDP_Permalink::atbdp_get_location_page( $term, $directory_type );

--- a/includes/model/ListingTaxonomy.php
+++ b/includes/model/ListingTaxonomy.php
@@ -257,7 +257,8 @@ class Directorist_Listing_Taxonomy {
 				if( ! empty( $_GET['directory_type'] ) ) {
 					$directory_type = sanitize_text_field( wp_unslash( $_GET['directory_type'] ) );
 				} else {
-					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : $this->current_listing_type;
+					$current = get_term_by( 'id', $this->current_listing_type, ATBDP_TYPE );
+					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : $current->slug;
 				}
 
 				$permalink = ( $this->type == 'category' ) ? ATBDP_Permalink::atbdp_get_category_page( $term, $directory_type ) : ATBDP_Permalink::atbdp_get_location_page( $term, $directory_type );

--- a/includes/model/ListingTaxonomy.php
+++ b/includes/model/ListingTaxonomy.php
@@ -257,7 +257,7 @@ class Directorist_Listing_Taxonomy {
 				if( ! empty( $_GET['directory_type'] ) ) {
 					$directory_type = sanitize_text_field( wp_unslash( $_GET['directory_type'] ) );
 				} else {
-					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : '';
+					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : $this->current_listing_type;
 				}
 
 				$permalink = ( $this->type == 'category' ) ? ATBDP_Permalink::atbdp_get_category_page( $term, $directory_type ) : ATBDP_Permalink::atbdp_get_location_page( $term, $directory_type );

--- a/includes/model/ListingTaxonomy.php
+++ b/includes/model/ListingTaxonomy.php
@@ -258,7 +258,7 @@ class Directorist_Listing_Taxonomy {
 					$directory_type = sanitize_text_field( wp_unslash( $_GET['directory_type'] ) );
 				} else {
 					$current = get_term_by( 'id', $this->current_listing_type, ATBDP_TYPE );
-					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : $current->slug;
+					$directory_type = ( 1 == $this->directory_type_count ) ? $this->directory_type[0] : ( ! is_wp_error( $current ) ? $current->slug : '' );
 				}
 
 				$permalink = ( $this->type == 'category' ) ? ATBDP_Permalink::atbdp_get_category_page( $term, $directory_type ) : ATBDP_Permalink::atbdp_get_location_page( $term, $directory_type );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Enable and create multiple directory
2. Add elementor widget and set a default directory type
3. See the category URL, it doesn't contain directory_type args

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
