### PR TITLE
added check to remove php warning caused by empty values

### DIFF
--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -302,11 +302,13 @@ class Directorist_Single_Listing {
 		switch ( $type ) {
 			case 'radio':
 			case 'select':
-			foreach( $data['options'] as $option ) {
-				$key = $option['option_value'];
-				if( $key === $value ) {
-					$result = $option['option_label'];
-					break;
+			if(!empty($data['options'])) {
+				foreach( $data['options'] as $option ) {
+					$key = $option['option_value'];
+					if( $key === $value ) {
+						$result = $option['option_label'];
+						break;
+					}
 				}
 			}
 			break;
@@ -545,7 +547,9 @@ class Directorist_Single_Listing {
 			];
 		}
 
-		$padding_top         = $data['height'] / $data['width'] * 100;
+		$height = !empty($data['height']) ? $data['height'] : 580; //set default height if no height present
+		$width = !empty($data['width']) ? $data['width'] : 740;  //set default width if no width present
+		$padding_top         = $height / $width * 100;
 		$data['padding-top'] = $padding_top;
 		return $data;
 	}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.
2.
3.

## Any linked issues
Fixes #1325 

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
