### PR TITLE
CSV importer miss to assign multiple taxonomy per listing

### DIFF
--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -179,34 +179,36 @@
 
                     if ( $tax_inputs ) {
                         foreach ( $tax_inputs as $taxonomy => $value ) {
+                            
+                            $taxonomy = ATBDP_TAGS;
+
                             if ('category' == $taxonomy) {
                                 $taxonomy = ATBDP_CATEGORY;
-                            } elseif ('location' == $taxonomy) {
+                            }
+                            
+                            if ('location' == $taxonomy) {
                                 $taxonomy = ATBDP_LOCATION;
-                            } else {
-                                $taxonomy = ATBDP_TAGS;
                             }
 
-                            $terms = ( isset( $post[ $value ] ) && ! empty( $final_term ) ) ? explode( ',', $final_term ) : [];
+                            $terms = ( isset( $post[ $value ] ) && ! empty( $value ) ) ? explode( ',', $value ) : array();
                             
                             if ( ! empty( $terms ) ) {
 
                                 $multiple = $terms > 0;
-                                $term_ids = [];
+                                $term_ids = array();
 
                                 foreach( $terms as $term ) {
-
                                     $term_exists = get_term_by( 'name', $term, $taxonomy );
-                                
                                     if ( ! $term_exists ) {
 
                                         $new_term = wp_insert_term( $term, $taxonomy );
-                                        
                                         if ( ! is_wp_error( $new_term ) ) {
+
                                             array_push( $term_ids, $new_term['term_id'] );
                                             update_term_meta( $new_term['term_id'], '_directory_type', [ $directory_type ] );
                                         }
                                     } else {
+
                                         array_push( $term_ids, $term_exists->term_id );
                                         update_term_meta( $term_exists->term_id, '_directory_type', [ $directory_type ] );
                                     }

--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -191,6 +191,7 @@
                             $final_terms = ( ! empty( $final_term ) ) ? explode( ',', $final_term ) : [];
 
                             if ( ! empty( $final_terms ) ) {
+                                $append = $final_terms > 0;
                                 foreach( $final_terms as $term_item ) {
                                     $term_exists = get_term_by( 'name', $term_item, $taxonomy );
                                 
@@ -199,11 +200,11 @@
                                         
                                         if ( ! is_wp_error( $result ) ) {
                                             $term_id = $result['term_id'];
-                                            wp_set_object_terms( $post_id, $term_id, $taxonomy);
+                                            wp_set_object_terms( $post_id, $term_id, $taxonomy, $append );
                                             update_term_meta( $term_id, '_directory_type', [ $directory_type ] );
                                         }
                                     } else {
-                                        wp_set_object_terms( $post_id, $term_exists->term_id, $taxonomy, true );
+                                        wp_set_object_terms( $post_id, $term_exists->term_id, $taxonomy, $append );
                                         update_term_meta( $term_exists->term_id, '_directory_type', [ $directory_type ] );
                                     }
                                 }

--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -178,7 +178,7 @@
                     $imported++;
 
                     if ( $tax_inputs ) {
-                        foreach ( $tax_inputs as $taxonomy => $term ) {
+                        foreach ( $tax_inputs as $taxonomy => $value ) {
                             if ('category' == $taxonomy) {
                                 $taxonomy = ATBDP_CATEGORY;
                             } elseif ('location' == $taxonomy) {
@@ -187,27 +187,32 @@
                                 $taxonomy = ATBDP_TAGS;
                             }
 
-                            $final_term  = isset( $post[ $term ] ) ? $post[ $term ] : '';
-                            $final_terms = ( ! empty( $final_term ) ) ? explode( ',', $final_term ) : [];
+                            $terms = ( isset( $post[ $value ] ) && ! empty( $final_term ) ) ? explode( ',', $final_term ) : [];
+                            
+                            if ( ! empty( $terms ) ) {
 
-                            if ( ! empty( $final_terms ) ) {
-                                $append = $final_terms > 0;
-                                foreach( $final_terms as $term_item ) {
-                                    $term_exists = get_term_by( 'name', $term_item, $taxonomy );
+                                $multiple = $terms > 0;
+                                $term_ids = [];
+
+                                foreach( $terms as $term ) {
+
+                                    $term_exists = get_term_by( 'name', $term, $taxonomy );
                                 
-                                    if ( ! $term_exists ) { // @codingStandardsIgnoreLine.
-                                        $result = wp_insert_term( $term_item, $taxonomy );
+                                    if ( ! $term_exists ) {
+
+                                        $new_term = wp_insert_term( $term, $taxonomy );
                                         
-                                        if ( ! is_wp_error( $result ) ) {
-                                            $term_id = $result['term_id'];
-                                            wp_set_object_terms( $post_id, $term_id, $taxonomy, $append );
-                                            update_term_meta( $term_id, '_directory_type', [ $directory_type ] );
+                                        if ( ! is_wp_error( $new_term ) ) {
+                                            array_push( $term_ids, $new_term['term_id'] );
+                                            update_term_meta( $new_term['term_id'], '_directory_type', [ $directory_type ] );
                                         }
                                     } else {
-                                        wp_set_object_terms( $post_id, $term_exists->term_id, $taxonomy, $append );
+                                        array_push( $term_ids, $term_exists->term_id );
                                         update_term_meta( $term_exists->term_id, '_directory_type', [ $directory_type ] );
                                     }
                                 }
+                                wp_set_object_terms( $post_id, $term_ids, $taxonomy, $multiple );
+
                             }
                             
                         }

--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -197,31 +197,31 @@
                                 $taxonomy = ATBDP_TAGS;
                             }
 
-                            $texonomy_terms = get_terms( array(
-                                'taxonomy' => $taxonomy,
-                                'hide_empty' => false,
-                            ) );
-
                             $term_ids = array();
                             $multiple = $terms > 0;
 
+                            $texonomy_terms = get_terms( array(
+                                'taxonomy' => $taxonomy,
+                                'hide_empty' => false,
+                                'name' => $terms
+                            ) );
+                            
                             foreach( $terms as $term ) {
 
                                 $key = array_search( $term, array_column( $texonomy_terms, 'name' ) );
+
                                 if( $key !== false ) {
                                     array_push( $term_ids, $texonomy_terms[$key]->term_id );
                                     update_term_meta( $texonomy_terms[$key]->term_id, '_directory_type', [ $directory_type ] );
-                                    continue;
-                                }
-                                $new_term = wp_insert_term( $term, $taxonomy );
-                                if( ! is_wp_error( $new_term ) ) {
-                                    array_push( $term_ids, $new_term['term_id'] );
-                                    update_term_meta( $new_term['term_id'], '_directory_type', [ $directory_type ] );
+                                }else{
+                                    $new_term = wp_insert_term( $term, $taxonomy );
+                                    if( ! is_wp_error( $new_term ) ) {
+                                        array_push( $term_ids, $new_term['term_id'] );
+                                        update_term_meta( $new_term['term_id'], '_directory_type', [ $directory_type ] );
+                                    }
                                 }
                             }
-
                             wp_set_object_terms( $post_id, $term_ids, $taxonomy, $multiple );
-                            
                         }
                     }
 
@@ -284,7 +284,6 @@
             $data['total']         = $total_length;
             $data['imported']      = $imported;
             $data['failed']        = $failed;
-            $data['dummy']        = $dummy;
 
             wp_send_json( $data );
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how do test the changes

1. run the importer using the attached csv
2. there should be multiple categories assigned to a few listings

[dummy.csv](https://github.com/sovware/directorist/files/10542829/dummy.csv)

## Any linked issues
 https://tasks.hubstaff.com/app/organizations/37274/projects/265387/tasks/5164517

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
