### PR TITLE
fix email not sending after completing a fresh order

### DIFF
--- a/includes/classes/class-email.php
+++ b/includes/classes/class-email.php
@@ -498,7 +498,7 @@ This email is sent automatically for information purpose only. Please do not res
 			if ( ! in_array( 'order_completed', get_directorist_option( 'notify_user', array( 'order_completed' ) ) ) ) {
 				return false;
 			}
-			$user = $this->get_owner( $listing_id );
+			$user = $this->get_owner( $listing_id ? $listing_id : $order_id );
 			$subject = $this->replace_in_content( get_directorist_option( 'email_sub_completed_order' ), $order_id, $listing_id, $user );
 			$body = $this->replace_in_content( get_directorist_option( 'email_tmpl_completed_order' ), $order_id, $listing_id, $user );
 			$message = atbdp_email_html( $subject, $body );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Register a new user
2. Activate Pricing Plan extension and select Direct Purchase in the option
3. Create a plan from admin and purchase it from the newly registered user
4. Customer should receive an order confirmation email


Question: Why is this fix in core instead of extension?
-- Directorist core doesn't have orders without listing but multiple modules have this feature to purchase products/services without any listing. So it's better to adjust the condition in the core.

## Any linked issues
https://tasks.hubstaff.com/app/organizations/37274/projects/265387/tasks/5198228

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
