### PR TITLE
fix map issue in single listing when address is not set but manual la…

### DIFF
--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -194,7 +194,10 @@ class Directorist_Single_Listing {
 
 			if( 'map' === $field['widget_name'] ) {
 				$address = get_post_meta( $this->id, '_address', true );
-				if( $address ) {
+				$manual_lat = get_post_meta( $this->id, '_manual_lat', true );
+				$manual_lng = get_post_meta( $this->id, '_manual_lng', true );
+
+				if( $address || ( $manual_lat && $manual_lng ) ) {
 					$has_contents = true;
 					break;
 				}


### PR DESCRIPTION
…titude and langlitude is present

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Add a listing with only pointing your address in map and keep the address field empty
2. Visit single listing page
3. No map!

## Any linked issues
Fixes # https://tasks.hubstaff.com/app/organizations/37274/projects/265387/tasks/5058303

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
