### PR TITLE
fixed directory builder widget label issue

### DIFF
--- a/assets/js/admin-main.js
+++ b/assets/js/admin-main.js
@@ -423,12 +423,12 @@ window.addEventListener('DOMContentLoaded', function () {
   );
   return $elem;
   }
-    $("#category_icon").select2({
+   $("#category_icon").select2({
   placeholder: directorist_admin.i18n_text.icon_choose_text,
   allowClear: true,
   templateResult: selecWithIcon,
   });
-    /* Show and hide manual coordinate input field */
+   /* Show and hide manual coordinate input field */
 
   if (!$('input#manual_coordinate').is(':checked')) {
     $('.directorist-map-coordinates').hide();
@@ -925,11 +925,11 @@ window.addEventListener('DOMContentLoaded', function () {
   });
   /* // Display the media uploader when "Upload Image" button clicked in the custom taxonomy "atbdp_categories"
   $( '#atbdp-categories-upload-image' ).on( 'click', function( e ) {
-    if (frame) {
+   if (frame) {
    frame.open();
    return;
   }
-    // Create a new media frame
+   // Create a new media frame
   frame = wp.media({
    title: directorist_admin.i18n_text.upload_cat_image,
    button: {

--- a/assets/js/admin-multi-directory-builder.js
+++ b/assets/js/admin-multi-directory-builder.js
@@ -26012,7 +26012,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
         label = widget.label;
       }
 
-      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.label.value && widget.options.fields.label.value.length) {
+      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.type === 'text' && widget.options.fields.label.value && widget.options.fields.label.value.length) {
         label = widget.options.fields.label.value;
       }
 

--- a/assets/js/admin-multi-directory-builder.js
+++ b/assets/js/admin-multi-directory-builder.js
@@ -26006,13 +26006,15 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       this.active_insert_widget_key = '';
     },
     getWidgetLabel: function getWidgetLabel(widget) {
+      var _widget$options, _widget$options$field, _widget$options$field2, _widget$options$field3, _widget$options2, _widget$options2$fiel;
+
       var label = '';
 
       if (typeof widget.label === 'string') {
         label = widget.label;
       }
 
-      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.type === 'text' && widget.options.fields.label.value && widget.options.fields.label.value.length) {
+      if (widget !== null && widget !== void 0 && (_widget$options = widget.options) !== null && _widget$options !== void 0 && (_widget$options$field = _widget$options.fields) !== null && _widget$options$field !== void 0 && (_widget$options$field2 = _widget$options$field.label) !== null && _widget$options$field2 !== void 0 && (_widget$options$field3 = _widget$options$field2.value) !== null && _widget$options$field3 !== void 0 && _widget$options$field3.length && (widget === null || widget === void 0 ? void 0 : (_widget$options2 = widget.options) === null || _widget$options2 === void 0 ? void 0 : (_widget$options2$fiel = _widget$options2.fields) === null || _widget$options2$fiel === void 0 ? void 0 : _widget$options2$fiel.type) === 'text') {
         label = widget.options.fields.label.value;
       }
 

--- a/assets/js/admin-multi-directory-builder.js
+++ b/assets/js/admin-multi-directory-builder.js
@@ -26006,15 +26006,13 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       this.active_insert_widget_key = '';
     },
     getWidgetLabel: function getWidgetLabel(widget) {
-      var _widget$options, _widget$options$field, _widget$options$field2, _widget$options$field3, _widget$options2, _widget$options2$fiel;
-
       var label = '';
 
       if (typeof widget.label === 'string') {
         label = widget.label;
       }
 
-      if (widget !== null && widget !== void 0 && (_widget$options = widget.options) !== null && _widget$options !== void 0 && (_widget$options$field = _widget$options.fields) !== null && _widget$options$field !== void 0 && (_widget$options$field2 = _widget$options$field.label) !== null && _widget$options$field2 !== void 0 && (_widget$options$field3 = _widget$options$field2.value) !== null && _widget$options$field3 !== void 0 && _widget$options$field3.length && (widget === null || widget === void 0 ? void 0 : (_widget$options2 = widget.options) === null || _widget$options2 === void 0 ? void 0 : (_widget$options2$fiel = _widget$options2.fields) === null || _widget$options2$fiel === void 0 ? void 0 : _widget$options2$fiel.type) === 'text') {
+      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.type === 'text' && widget.options.fields.label.value && widget.options.fields.label.value.length) {
         label = widget.options.fields.label.value;
       }
 

--- a/assets/js/admin-settings-manager.js
+++ b/assets/js/admin-settings-manager.js
@@ -26075,7 +26075,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
         label = widget.label;
       }
 
-      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.label.value && widget.options.fields.label.value.length) {
+      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.type === 'text' && widget.options.fields.label.value && widget.options.fields.label.value.length) {
         label = widget.options.fields.label.value;
       }
 

--- a/assets/js/admin-settings-manager.js
+++ b/assets/js/admin-settings-manager.js
@@ -26069,13 +26069,15 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       this.active_insert_widget_key = '';
     },
     getWidgetLabel: function getWidgetLabel(widget) {
+      var _widget$options, _widget$options$field, _widget$options$field2, _widget$options$field3, _widget$options2, _widget$options2$fiel;
+
       var label = '';
 
       if (typeof widget.label === 'string') {
         label = widget.label;
       }
 
-      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.type === 'text' && widget.options.fields.label.value && widget.options.fields.label.value.length) {
+      if (widget !== null && widget !== void 0 && (_widget$options = widget.options) !== null && _widget$options !== void 0 && (_widget$options$field = _widget$options.fields) !== null && _widget$options$field !== void 0 && (_widget$options$field2 = _widget$options$field.label) !== null && _widget$options$field2 !== void 0 && (_widget$options$field3 = _widget$options$field2.value) !== null && _widget$options$field3 !== void 0 && _widget$options$field3.length && (widget === null || widget === void 0 ? void 0 : (_widget$options2 = widget.options) === null || _widget$options2 === void 0 ? void 0 : (_widget$options2$fiel = _widget$options2.fields) === null || _widget$options2$fiel === void 0 ? void 0 : _widget$options2$fiel.type) === 'text') {
         label = widget.options.fields.label.value;
       }
 

--- a/assets/js/admin-settings-manager.js
+++ b/assets/js/admin-settings-manager.js
@@ -26069,15 +26069,13 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       this.active_insert_widget_key = '';
     },
     getWidgetLabel: function getWidgetLabel(widget) {
-      var _widget$options, _widget$options$field, _widget$options$field2, _widget$options$field3, _widget$options2, _widget$options2$fiel;
-
       var label = '';
 
       if (typeof widget.label === 'string') {
         label = widget.label;
       }
 
-      if (widget !== null && widget !== void 0 && (_widget$options = widget.options) !== null && _widget$options !== void 0 && (_widget$options$field = _widget$options.fields) !== null && _widget$options$field !== void 0 && (_widget$options$field2 = _widget$options$field.label) !== null && _widget$options$field2 !== void 0 && (_widget$options$field3 = _widget$options$field2.value) !== null && _widget$options$field3 !== void 0 && _widget$options$field3.length && (widget === null || widget === void 0 ? void 0 : (_widget$options2 = widget.options) === null || _widget$options2 === void 0 ? void 0 : (_widget$options2$fiel = _widget$options2.fields) === null || _widget$options2$fiel === void 0 ? void 0 : _widget$options2$fiel.type) === 'text') {
+      if (this.isObject(widget.options) && widget.options.fields && widget.options.fields.label && widget.options.fields.type === 'text' && widget.options.fields.label.value && widget.options.fields.label.value.length) {
         label = widget.options.fields.label.value;
       }
 

--- a/assets/src/js/admin/vue/modules/form-fields/Card_Builder_Listing_Header_Field.vue
+++ b/assets/src/js/admin/vue/modules/form-fields/Card_Builder_Listing_Header_Field.vue
@@ -6,7 +6,7 @@
         v-bind="widgetCardOptionsWindow"
         @close="closeCardWidgetOptionsWindow()"
       />
-      
+
       <options-window
         :active="widgetOptionsWindowActiveStatus"
         v-bind="widgetOptionsWindow"
@@ -200,7 +200,7 @@ export default {
     output_data() {
       let output = {};
       let layout = this.local_layout;
-      
+
       // Parse Layout
       for ( let section in layout ) {
         output[section] = {};
@@ -225,7 +225,7 @@ export default {
             if ( ! this.active_widgets[widget_name] && typeof this.active_widgets[widget_name] !== "object") {
               continue;
             }
-            
+
             let widget_data = {};
             for ( let root_option in this.active_widgets[widget_name] ) {
               if ( 'options' === root_option ) { continue; }
@@ -297,7 +297,7 @@ export default {
         if ( this.isObject( available_widgets[ widget ].show_if ) ) {
           show_if_cond_state = this.checkShowIfCondition( { condition: available_widgets[ widget ].show_if } );
           let main_widget = available_widgets[ widget ];
-          
+
           delete available_widgets[ widget ];
 
           if ( show_if_cond_state.status ) {
@@ -315,13 +315,13 @@ export default {
               if ( typeof matched_field.label === 'string' && matched_field.label.length ) {
                 _main_widget.label = matched_field.label;
               }
- 
+
               available_widgets[ current_key ] = _main_widget;
               widget_keys.push( current_key );
             }
           }
         }
-      
+
       }
 
       return available_widgets;
@@ -432,7 +432,7 @@ export default {
       // Import Layout
       // -------------------------
       let selectedWidgets = [];
-      
+
       // Get Active Widgets Data
       let active_widgets_data = {};
       for ( let section in value ) {
@@ -464,7 +464,7 @@ export default {
 
         let widgets_template = { ...this.theAvailableWidgets[widget_key] };
         let widget_options = ( ! active_widgets_data[widget_key].options && typeof active_widgets_data[widget_key].options !== "object" ) ? false : active_widgets_data[widget_key].options;
-       
+
         let has_widget_options = false;
         if ( widgets_template.options && widgets_template.options.fields ) {
           has_widget_options = true;
@@ -495,10 +495,10 @@ export default {
         this.local_layout[ item.section ][ item.area ].selectedWidgets.splice( length, 0, item.widget );
       }
 
-      
+
       // Import Options
       // -------------------------
-      
+
       if ( ! this.isTruthyObject( value.options ) ) { return; }
 
       for ( let section in value.options ) {
@@ -541,7 +541,7 @@ export default {
       }
 
       for ( let section in this.local_layout ) {
-        
+
         if ( ! this.isTruthyObject( this.layout[ section ] ) ) {
           continue;
         }
@@ -604,7 +604,7 @@ export default {
       if ( ! this.widgetIsAccepted( path, this._currentDraggingWidget.key ) ) {
         return false;
       }
-      
+
       return true;
     },
 
@@ -623,8 +623,8 @@ export default {
 
       this.onDragEndWidget();
     },
-    
-    
+
+
     handleDropOnPlaceholder( dest ) {
       // return;
       const key  = this.currentDraggingWidget.key;
@@ -651,7 +651,7 @@ export default {
     handleDragOverOnPlaceholder( where ) {
       // console.log( 'handleDragOverOnPlaceholder', where );
     },
-    
+
     handleDragleaveOnPlaceholder( where ) {
       // console.log( 'handleDragleaveOnPlaceholder', where );
     },
@@ -692,7 +692,7 @@ export default {
       if ( typeof this.card_option_widgets[ options_window.widget ] === 'undefined' ) {
         return;
       }
-      
+
       if ( typeof this.card_option_widgets[ options_window.widget ].options === 'undefined' ) {
         return;
       }
@@ -724,7 +724,7 @@ export default {
 
     trashWidget( key, where ) {
       if ( ! where.selectedWidgets.includes( key ) ) { return; }
-      
+
       let index = where.selectedWidgets.indexOf( key );
       Vue.delete( where.selectedWidgets, index);
 
@@ -772,10 +772,11 @@ export default {
         label = widget.label;
       }
 
-      if ( 
-        this.isObject( widget.options ) && 
-        widget.options.fields && 
-        widget.options.fields.label && 
+      if (
+        this.isObject( widget.options ) &&
+        widget.options.fields &&
+        widget.options.fields.label &&
+        widget.options.fields.type === 'text' &&
         widget.options.fields.label.value &&
         widget.options.fields.label.value.length
       ) {

--- a/assets/src/js/admin/vue/modules/form-fields/Card_Builder_Listing_Header_Field.vue
+++ b/assets/src/js/admin/vue/modules/form-fields/Card_Builder_Listing_Header_Field.vue
@@ -772,7 +772,14 @@ export default {
         label = widget.label;
       }
 
-      if ( widget?.options?.fields?.label?.value?.length && widget?.options?.fields?.type === 'text' ) {
+      if (
+        this.isObject( widget.options ) &&
+        widget.options.fields &&
+        widget.options.fields.label &&
+        widget.options.fields.type === 'text' &&
+        widget.options.fields.label.value &&
+        widget.options.fields.label.value.length
+      ) {
         label = widget.options.fields.label.value;
       }
 

--- a/assets/src/js/admin/vue/modules/form-fields/Card_Builder_Listing_Header_Field.vue
+++ b/assets/src/js/admin/vue/modules/form-fields/Card_Builder_Listing_Header_Field.vue
@@ -772,14 +772,7 @@ export default {
         label = widget.label;
       }
 
-      if (
-        this.isObject( widget.options ) &&
-        widget.options.fields &&
-        widget.options.fields.label &&
-        widget.options.fields.type === 'text' &&
-        widget.options.fields.label.value &&
-        widget.options.fields.label.value.length
-      ) {
+      if ( widget?.options?.fields?.label?.value?.length && widget?.options?.fields?.type === 'text' ) {
         label = widget.options.fields.label.value;
       }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
The card option fields in the 'card-builder' widget uses label from its root, but if the option fields contains label field in it then it uses that value instead of the root label.

The back button widget has a toggle field and its key is defined as 'label' which is not appropriate for its kind.
Therefore the card option field was using its boolean value as the widget label.

So I have added an additional check on the 'getWidgetLabel' helper to skip the label field if its type is not text.

## Any linked issues
[Task: Fix - Directory Builder - Listing Header - Back Button Issue](https://tasks.hubstaff.com/app/organizations/37274/projects/265386/tasks/5316474)

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
