### PR TITLE
fix fatal error with php 8

### DIFF
--- a/templates/listing-form/custom-fields/checkbox.php
+++ b/templates/listing-form/custom-fields/checkbox.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 6.7
+ * @version 7.6
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 				<?php $uniqid = $option['option_value'] . '-' .wp_rand();  ?>
 
 				<div class="directorist-checkbox directorist-mb-10">
-					<input type="checkbox" id="<?php echo esc_attr( $uniqid ); ?>" name="<?php echo esc_attr( $data['field_key'] ); ?>[]" value="<?php echo esc_attr( $option['option_value'] ); ?>" <?php echo in_array( $option['option_value'], $data['value'] ) ? 'checked="checked"' : '' ; ?>>
+					<input type="checkbox" id="<?php echo esc_attr( $uniqid ); ?>" name="<?php echo esc_attr( $data['field_key'] ); ?>[]" value="<?php echo esc_attr( $option['option_value'] ); ?>" <?php echo is_array( $data['value'] ) && in_array( $option['option_value'], $data['value'] ) ? 'checked="checked"' : '' ; ?>>
 					<label for="<?php echo esc_attr( $uniqid ); ?>" class="directorist-checkbox__label"><?php echo esc_html( $option['option_label'] ); ?></label>
 				</div>
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Upgrade to php 8.1
2. Try importing directory type from https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/5294307

## Any linked issues
Fixes #https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/5294307

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
