### PR TITLE
Sanitized settings json data for invalid UTF-8 characters

### DIFF
--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -5421,14 +5421,19 @@ Please remember that your order may be canceled if you do not make your payment 
 		 * @return array Fields
 		 */
 		public function sanitize_fields_data( $fields ) {
+
 			foreach( $fields['fields'] as $key => $field_args ) {
 
 				foreach( $field_args as $field_args_key => $field_args_value ) {
-					if ( in_array( $field_args_key, [ 'type', 'value' ] ) ) {
+
+					$type = isset( $field_args['type'] ) ? $field_args['type'] : 'text';
+
+					if ( 'value' === $field_args_key && $type === 'textarea' ) {
+						$fields['fields'][ $key ][ $field_args_key ] = sanitize_textarea_field( $field_args_value );
 						continue;
 					}
 
-					$fields['fields'][ $key ][ $field_args_key ] = sanitize_text_field( $field_args_value );
+					$fields['fields'][ $key ][ $field_args_key ] = directorist_clean( $field_args_value );
 				}
 
 			}

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -5428,7 +5428,7 @@ Please remember that your order may be canceled if you do not make your payment 
 
 					$type = isset( $field_args['type'] ) ? $field_args['type'] : 'text';
 
-					if ( 'value' === $field_args_key && $type === 'textarea' ) {
+					if ( 'value' === $field_args_key && 'textarea' === $type ) {
 						$fields[ $key ][ $field_args_key ] = sanitize_textarea_field( $field_args_value );
 						continue;
 					}

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -5405,13 +5405,36 @@ Please remember that your order may be canceled if you do not make your payment 
 
             var_dump( [ '$check_new' => $check_new,  '$check_edit' => $check_edit] ); */
 
+			$settings_builder_data['fields'] = $this->sanitize_fields_data( $settings_builder_data['fields'] );
 
             $data = [
-                'settings_builder_data' => base64_encode( json_encode( $settings_builder_data, JSON_INVALID_UTF8_IGNORE ) )
+                'settings_builder_data' => base64_encode( json_encode( $settings_builder_data ) )
             ];
 
             atbdp_load_admin_template( 'settings-manager/settings', $data );
         }
+
+		/**
+		 * Sanitize Fields Data
+		 *
+		 * @param array $fields
+		 * @return array Fields
+		 */
+		public function sanitize_fields_data( $fields ) {
+			foreach( $fields['fields'] as $key => $field_args ) {
+
+				foreach( $field_args as $field_args_key => $field_args_value ) {
+					if ( in_array( $field_args_key, [ 'type', 'value' ] ) ) {
+						continue;
+					}
+
+					$fields['fields'][ $key ][ $field_args_key ] = sanitize_text_field( $field_args_value );
+				}
+
+			}
+
+			return $fields;
+		}
 
         /**
          * Get all the pages in an array where each page is an array of key:value:id and key:label:name

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -5407,7 +5407,7 @@ Please remember that your order may be canceled if you do not make your payment 
 
 
             $data = [
-                'settings_builder_data' => base64_encode( json_encode( $settings_builder_data ) )
+                'settings_builder_data' => base64_encode( json_encode( $settings_builder_data, JSON_INVALID_UTF8_IGNORE ) )
             ];
 
             atbdp_load_admin_template( 'settings-manager/settings', $data );

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -5422,18 +5422,18 @@ Please remember that your order may be canceled if you do not make your payment 
 		 */
 		public function sanitize_fields_data( $fields ) {
 
-			foreach( $fields['fields'] as $key => $field_args ) {
+			foreach( $fields as $key => $field_args ) {
 
 				foreach( $field_args as $field_args_key => $field_args_value ) {
 
 					$type = isset( $field_args['type'] ) ? $field_args['type'] : 'text';
 
 					if ( 'value' === $field_args_key && $type === 'textarea' ) {
-						$fields['fields'][ $key ][ $field_args_key ] = sanitize_textarea_field( $field_args_value );
+						$fields[ $key ][ $field_args_key ] = sanitize_textarea_field( $field_args_value );
 						continue;
 					}
 
-					$fields['fields'][ $key ][ $field_args_key ] = directorist_clean( $field_args_value );
+					$fields[ $key ][ $field_args_key ] = directorist_clean( $field_args_value );
 				}
 
 			}

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -5433,6 +5433,11 @@ Please remember that your order may be canceled if you do not make your payment 
 						continue;
 					}
 
+					if ( 'value' === $field_args_key && 'number' === $type ) {
+						$fields[ $key ][ $field_args_key ] = floatval( sanitize_text_field( $field_args_value ) );
+						continue;
+					}
+
 					$fields[ $key ][ $field_args_key ] = directorist_clean( $field_args_value );
 				}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Change the language to Korean language.
2. Save the settings with some invalid UTF-8 character.
3. Reload the page and check if settings panel loads properly.

## Linked Issue
[Issue #](https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/5432870)


- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
