### PR TITLE
Fix/listing import issue

### DIFF
--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -18,7 +18,6 @@
         public $importable_fields = [];
         private $default_directory;
 
-
         public function __construct()
         {
 			// Prevent frontend executions.
@@ -57,7 +56,7 @@
 
             ob_start();
 
-            ATBDP()->load_template( 'admin-templates/import-export/data-table', array( 'data' => csv_get_data( $file, false, $delimiter ), 'fields' => $this->importable_fields, 'csv_file' => $file ) );
+            ATBDP()->load_template( 'admin-templates/import-export/data-table', array( 'data' => csv_get_data( $file, false, $delimiter ), 'fields' => $this->get_importable_fields(), 'csv_file' => $file ) );
 
             $response = ob_get_clean();
 
@@ -451,7 +450,7 @@
                     }
                 }
 
-                apply_filters( 'directorist_importable_fields', $this->importable_fields[ $field_key ] = $label );
+                $this->importable_fields[ $field_key ] = $label;
             }
         }
 
@@ -477,7 +476,7 @@
             $data = [
                 'data'     => $csv_data,
                 'csv_file' => $file_path,
-                'fields'   => $this->importable_fields
+                'fields'   => $this->get_importable_fields(),
             ];
 
             ATBDP()->load_template('admin-templates/import-export/data-table', $data );
@@ -588,6 +587,10 @@
             ATBDP()->load_template( $template_path, $template_data );
 
         }
+
+		public function get_importable_fields() {
+			return apply_filters( 'directorist_importable_fields', $this->importable_fields );
+		}
     }
 
 endif;

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -3659,7 +3659,7 @@ function directorist_set_listing_views_count( $listing_id = 0 ) {
  */
 function directorist_translate_to_listing_field_key( $header_key = '' ) {
 	//
-    $fields_map = array(
+    $fields_map = apply_filters( 'directorist_listings_field_label_to_key_map', array(
 		'date'                     => 'publish_date',
 		'publish_date'             => 'publish_date',
 		'Published'                => 'publish_date',
@@ -3718,7 +3718,7 @@ function directorist_translate_to_listing_field_key( $header_key = '' ) {
 		'Tagline'                  => 'tagline',
 		'address'                  => 'address',
 		'Address'                  => 'address',
-    );
+    ) );
 
     return isset( $fields_map[ $header_key ] ) ? $fields_map[ $header_key ] : '';
 }

--- a/views/admin-templates/import-export/data-table.php
+++ b/views/admin-templates/import-export/data-table.php
@@ -5,7 +5,8 @@
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 $headers = $args['data'];
-$fields = $args['fields'];
+$fields  = $args['fields'];
+
 ?>
 <input type="hidden" name="csv_file" value="<?php echo esc_attr( $args['csv_file'] ) ?>">
 <table class="widefat atbdp-importer-mapping-table">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

### Issue 1
1. Create two category/location with parent child relationship.
2. Import listings from a CSV file with the child category/location fields.
3. The importer will create a new category/location field instead of linking exiting ones.

### Issue 2
The importer data mapping table does not have any support to extend it for the extensions. So appropriate filter hooks are applied for extending the data mapping table.

## Issues
https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/5793817

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
