### PR TITLE
fix email header issue on contact listing owner

### DIFF
--- a/includes/classes/class-ajax-handler.php
+++ b/includes/classes/class-ajax-handler.php
@@ -1324,8 +1324,7 @@ if ( ! class_exists( 'ATBDP_Ajax_Handler' ) ) :
 			$subject  = strtr( $contact_email_subject, $placeholders );
 			$message  = strtr( $contact_email_body, $placeholders );
 			$message  = nl2br( $message );
-			$headers  = "From: {$name} <{$site_email}>\r\n";
-			$headers .= "Reply-To: {$email}\r\n";
+			$headers  = ATBDP()->email->get_email_headers();
 			$message  = atbdp_email_html( $subject, $message );
 			// return true or false, based on the result
 			$is_sent = ATBDP()->email->send_mail( $to, $subject, $message, $headers ) ? true : false;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

When a user sends a message to a listing owner, the email notification that gets sent to the listing owner is coming from my WordPress Admin email account instead of from the email address that is configured at the Directory Listing ->Settings->Email->General Email settings.

## Any linked issues
Fixes # https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/6164498

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
