### PR TITLE
fix conflict with pricing plan

### DIFF
--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -726,7 +726,7 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 				$states['listing_is_featured']    = ( ! empty( $posted_data['listing_type'] ) && ( 'featured' === $posted_data['listing_type'] ) ) ? true : false;
 				$states['is_monetizable']         = ( $states['monetization_is_enable'] && $states['featured_enabled'] && $states['listing_is_featured'] ) ? true : false;
 
-				if ( $states['is_monetizable'] ) {
+				if ( $states['is_monetizable'] && ! is_fee_manager_active() ) {
 					$payment_status            = Directorist\Helper::get_listing_payment_status( $post_id );
 					$rejectable_payment_status = array( 'failed', 'cancelled', 'refunded' );
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how do test the changes

- Activate WooCommerce Pricing plan extension
- Purchase a package and try to submit a featured listings
- It will again redirect to checkout even though he already paid it for

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
