### PR TITLE
Fix Category Icon

### DIFF
--- a/includes/helpers/trait-icon-helper.php
+++ b/includes/helpers/trait-icon-helper.php
@@ -52,6 +52,11 @@ trait Icon_Helper {
 	 */
 	private static function get_font_awesome_file( $icon ) {
 		list( $prefix, $name ) = array_pad( explode( ' ', $icon ), 2, '' );
+
+		if ( ! $name ) { 
+			return '';
+		}
+
 		$filename              = str_replace( 'fa-', '', $name );
 		$filename              = $filename . '.svg';
 
@@ -92,6 +97,11 @@ trait Icon_Helper {
 	 */
 	private static function get_line_awesome_file( $icon ) {
 		list( $prefix, $name ) = array_pad( explode( ' ', $icon ), 2, '' );
+		
+		if ( ! $name ) { 
+			return '';
+		}
+
 		$filename              = str_replace( 'la-', '', $name );
 
 		$lar_file = 'line-awesome/svgs/' . $filename . '.svg';
@@ -160,6 +170,11 @@ trait Icon_Helper {
 	 */
 	private static function get_unicons_file( $icon ) {
 		list( $prefix, $name ) = array_pad( explode( ' ', $icon ), 2, '' );
+		
+		if ( ! $name ) { 
+			return '';
+		}
+
 		if ( $prefix == 'uil' ) {
 			$filename = str_replace( 'uil-', '', $name );
 			$dir      = 'unicons/svgs/line/';

--- a/includes/helpers/trait-icon-helper.php
+++ b/includes/helpers/trait-icon-helper.php
@@ -51,7 +51,7 @@ trait Icon_Helper {
 	 * @return string
 	 */
 	private static function get_font_awesome_file( $icon ) {
-		list( $prefix, $name ) = explode( ' ', $icon );
+		list( $prefix, $name ) = array_pad( explode( ' ', $icon ), 2, '' );
 		$filename              = str_replace( 'fa-', '', $name );
 		$filename              = $filename . '.svg';
 

--- a/includes/helpers/trait-icon-helper.php
+++ b/includes/helpers/trait-icon-helper.php
@@ -91,7 +91,7 @@ trait Icon_Helper {
 	 * @return string
 	 */
 	private static function get_line_awesome_file( $icon ) {
-		list( $prefix, $name ) = explode( ' ', $icon );
+		list( $prefix, $name ) = array_pad( explode( ' ', $icon ), 2, '' );
 		$filename              = str_replace( 'la-', '', $name );
 
 		$lar_file = 'line-awesome/svgs/' . $filename . '.svg';
@@ -159,13 +159,12 @@ trait Icon_Helper {
 	 * @return string
 	 */
 	private static function get_unicons_file( $icon ) {
-		$slice = explode( ' ', $icon );
-
-		if ( $slice[0] == 'uil' ) {
-			$filename = str_replace( 'uil-', '', $slice[1] );
+		list( $prefix, $name ) = array_pad( explode( ' ', $icon ), 2, '' );
+		if ( $prefix == 'uil' ) {
+			$filename = str_replace( 'uil-', '', $name );
 			$dir      = 'unicons/svgs/line/';
-		} elseif ( $slice[0] == 'uis' ) {
-			$filename = str_replace( 'uis-', '', $slice[1] );
+		} elseif ( $prefix == 'uis' ) {
+			$filename = str_replace( 'uis-', '', $name );
 			$dir      = 'unicons/svgs/solid/';
 		} else {
 			return '';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

Issue found in client site, if the icon `string` doesn't have any space then the `explode` function will not deliver an `array` with 2 indexes, here `array_pad` is best before `list` any dynamic array

<img width="757" alt="image" src="https://github.com/sovware/directorist/assets/36886362/11820fd0-5998-48a2-ac20-d84f0afa6af5">


## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
