### PR TITLE
Fix fatal error when no listings reference in an order

### DIFF
--- a/includes/classes/class-email.php
+++ b/includes/classes/class-email.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'ATBDP_Email' ) ) :
 				$listing_id = (int) get_post_meta( $order_id, '_listing_id', true );
 			}
 			if ( empty( $user ) ) {
-				$post_author_id = get_post_field( 'post_author', $listing_id );
+				$post_author_id = get_post_field( 'post_author', $listing_id ? $listing_id : $order_id );
 				$user = get_userdata( $post_author_id );
 			} else {
 				if ( ! $user instanceof WP_User ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Activate Pricing Plans extension
2. Go to Settings >> Extensions >> Pricing Plans and enable Direct Purchase
3. Create a free plan
4. Enable guest login
5. Try to purchase the plan from a private window

## Any linked issues
Fixes # https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/8578307

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
