### PR TITLE
Fix: javascript:void(0) issue creating trouble for SEO

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1752,12 +1752,12 @@ function the_atbdp_favourites_link( $post_id = 0 ) {
 
         $favourites = directorist_get_user_favorites( get_current_user_id() );
         if ( in_array( $post_id, $favourites ) ) {
-            return directorist_icon( 'las la-heart', false, 'directorist-added-to-favorite') . '<a href="javascript:void(0)" class="atbdp-favourites" data-post_id="' . $post_id . '"></a>';
+            return directorist_icon( 'las la-heart', false, 'directorist-added-to-favorite') . '<a href="#" class="atbdp-favourites" data-post_id="' . $post_id . '"></a>';
         } else {
-            return directorist_icon( 'las la-heart', false ) . '<a href="javascript:void(0)" class="atbdp-favourites" data-post_id="' . $post_id . '"></a>';
+            return directorist_icon( 'las la-heart', false ) . '<a href="#" class="atbdp-favourites" data-post_id="' . $post_id . '"></a>';
         }
     } else {
-        return '<a href="javascript:void(0)" class="atbdp-require-login">'.directorist_icon( 'las la-heart', false ).'</a>';
+        return '<a href="#" class="atbdp-require-login">'.directorist_icon( 'las la-heart', false ).'</a>';
     }
 }
 

--- a/templates/single/fields/report.php
+++ b/templates/single/fields/report.php
@@ -1,23 +1,22 @@
 <?php
-
 /**
  * @author  wpWax
  * @since   6.7
- * @version 7.5.0
+ * @version 7.8.0
  */
 
-if (!defined('ABSPATH')) exit;
+if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
 
-<div class="directorist-single-listing-action directorist-action-report directorist-tooltip directorist-btn-modal directorist-btn-modal-js" data-directorist_target="directorist-report-abuse-modal" data-label="<?php esc_html_e('Report', 'directorist'); ?>">
+<div class="directorist-single-listing-action directorist-action-report directorist-tooltip directorist-btn-modal directorist-btn-modal-js" data-directorist_target="directorist-report-abuse-modal" data-label="<?php esc_html_e( 'Report', 'directorist' ); ?>">
 
-	<?php if (is_user_logged_in()) : ?>
-		<a class="directorist-action-report-loggedin" href="#"><?php directorist_icon($icon); ?></a>
-	<?php else : ?>
-		<a class="directorist-action-report-not-loggedin" href="#"><?php directorist_icon($icon); ?></a>
+	<?php if ( is_user_logged_in() ): ?>
+		<a class="directorist-action-report-loggedin" href="#"><?php directorist_icon( $icon );?></a>
+	<?php else: ?>
+		<a class="directorist-action-report-not-loggedin" href="#"><?php directorist_icon( $icon );?></a>
 	<?php endif; ?>
 
-	<input type="hidden" id="atbdp-post-id" value="<?php echo esc_attr($listing->id); ?>" />
+	<input type="hidden" id="atbdp-post-id" value="<?php echo esc_attr( $listing->id ); ?>"/>
 
 </div>
 
@@ -41,9 +40,9 @@ if (!defined('ABSPATH')) exit;
 
 					<div class="directorist-form-group">
 
-						<label for="directorist-report-message"><?php esc_html_e('Your Complaint', 'directorist'); ?><span class="directorist-report-star">*</span></label>
+						<label for="directorist-report-message"><?php esc_html_e( 'Your Complaint', 'directorist' ); ?><span class="directorist-report-star">*</span></label>
 
-						<textarea class="directorist-form-element" id="directorist-report-message" rows="3" placeholder="<?php esc_attr_e('Message...', 'directorist'); ?>" required></textarea>
+						<textarea class="directorist-form-element" id="directorist-report-message" rows="3" placeholder="<?php esc_attr_e( 'Message...', 'directorist' ); ?>" required></textarea>
 
 					</div>
 
@@ -55,7 +54,7 @@ if (!defined('ABSPATH')) exit;
 
 				<div class="directorist-modal__footer">
 
-					<button type="submit" class="directorist-btn directorist-btn-primary directorist-btn-sm"><?php esc_html_e('Submit', 'directorist'); ?></button>
+					<button type="submit" class="directorist-btn directorist-btn-primary directorist-btn-sm"><?php esc_html_e( 'Submit', 'directorist' ); ?></button>
 
 				</div>
 

--- a/templates/single/fields/report.php
+++ b/templates/single/fields/report.php
@@ -1,22 +1,23 @@
 <?php
+
 /**
  * @author  wpWax
  * @since   6.7
  * @version 7.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if (!defined('ABSPATH')) exit;
 ?>
 
-<div class="directorist-single-listing-action directorist-action-report directorist-tooltip directorist-btn-modal directorist-btn-modal-js" data-directorist_target="directorist-report-abuse-modal" data-label="<?php esc_html_e( 'Report', 'directorist' ); ?>">
+<div class="directorist-single-listing-action directorist-action-report directorist-tooltip directorist-btn-modal directorist-btn-modal-js" data-directorist_target="directorist-report-abuse-modal" data-label="<?php esc_html_e('Report', 'directorist'); ?>">
 
-	<?php if ( is_user_logged_in() ): ?>
-		<a class="directorist-action-report-loggedin" href="#"><?php directorist_icon( $icon );?></a>
-	<?php else: ?>
-		<a class="directorist-action-report-not-loggedin" href="javascript:void(0)"><?php directorist_icon( $icon );?></a>
+	<?php if (is_user_logged_in()) : ?>
+		<a class="directorist-action-report-loggedin" href="#"><?php directorist_icon($icon); ?></a>
+	<?php else : ?>
+		<a class="directorist-action-report-not-loggedin" href="#"><?php directorist_icon($icon); ?></a>
 	<?php endif; ?>
 
-	<input type="hidden" id="atbdp-post-id" value="<?php echo esc_attr( $listing->id ); ?>"/>
+	<input type="hidden" id="atbdp-post-id" value="<?php echo esc_attr($listing->id); ?>" />
 
 </div>
 
@@ -40,9 +41,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 					<div class="directorist-form-group">
 
-						<label for="directorist-report-message"><?php esc_html_e( 'Your Complaint', 'directorist' ); ?><span class="directorist-report-star">*</span></label>
+						<label for="directorist-report-message"><?php esc_html_e('Your Complaint', 'directorist'); ?><span class="directorist-report-star">*</span></label>
 
-						<textarea class="directorist-form-element" id="directorist-report-message" rows="3" placeholder="<?php esc_attr_e( 'Message...', 'directorist' ); ?>" required></textarea>
+						<textarea class="directorist-form-element" id="directorist-report-message" rows="3" placeholder="<?php esc_attr_e('Message...', 'directorist'); ?>" required></textarea>
 
 					</div>
 
@@ -54,7 +55,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 				<div class="directorist-modal__footer">
 
-					<button type="submit" class="directorist-btn directorist-btn-primary directorist-btn-sm"><?php esc_html_e( 'Submit', 'directorist' ); ?></button>
+					<button type="submit" class="directorist-btn directorist-btn-primary directorist-btn-sm"><?php esc_html_e('Submit', 'directorist'); ?></button>
 
 				</div>
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix

## Description
How to reproduce the issue or how to test the changes

1. Need to do nothing.  Because of this "javascript:void(0)", google takes this link (single listing) as an invalid link and removes it from the list. Received this complaint from 10+ users till now.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
