### PR TITLE
add filter hook: filter the order amount for email receipt

### DIFF
--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -92,7 +92,22 @@ class ATBDP_Order
                 <td>
                     <?php
                     $amount = get_post_meta($order_id, '_amount', true);
-                    echo esc_html( $before . $amount . $after );
+
+                    /**
+                     * Filter the order amount for email receipt.
+                     *
+                     * Allows developers to modify the order amount before it is used in email receipts.
+                     *
+                     * @since 7.8.0
+                     *
+                     * @param float $amount   The order amount.
+                     * @param int   $order_id The order ID.
+                     *
+                     * @return float The filtered order amount.
+                     */
+                    $total_amount = apply_filters('directorist_email_receipt_order_amount', $amount, $order_id);
+
+                    echo esc_html( $before . $total_amount . $after );
                     do_action('atbdp_email_receipt_after_total_price', $listing_id);
                     ?>
                 </td>

--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -91,7 +91,7 @@ class ATBDP_Order
                 </td>
                 <td>
                     <?php
-                    $amount = get_post_meta($order_id, '_amount', true);
+                    $amount = get_post_meta( $order_id, '_amount', true );
 
                     /**
                      * Filter the order amount for email receipt.
@@ -105,10 +105,10 @@ class ATBDP_Order
                      *
                      * @return float The filtered order amount.
                      */
-                    $total_amount = apply_filters('directorist_email_receipt_order_amount', $amount, $order_id);
+                    $total_amount = apply_filters( 'directorist_email_receipt_order_amount', $amount, $order_id );
 
                     echo esc_html( $before . $total_amount . $after );
-                    do_action('atbdp_email_receipt_after_total_price', $listing_id);
+                    do_action( 'atbdp_email_receipt_after_total_price', $listing_id );
                     ?>
                 </td>
             </tr>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ ] Improvement

## Description
How to reproduce the issue or how to test the changes

Added a new filter hook named "directorist_email_receipt_order_amount" which contains two parameters:
float $amount   The order amount.
int   $order_id The order ID.

## Any linked issues
Fixes #

None

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
