### PR TITLE
fix fatal error on passing non user instance

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -3995,7 +3995,11 @@ function directorist_get_page_id( string $page_name = '' ) : int {
     return (int) apply_filters( 'directorist_page_id', $page_id, $page_name );
 }
 
-function directorist_password_reset_url(\Wp_User $user, $password_reset = true, $confirm_mail = false) {
+function directorist_password_reset_url( $user, $password_reset = true, $confirm_mail = false) {
+
+    if ( ! $user instanceof \Wp_User ) {
+        return;
+    }
 
     $args = array(
         'user' => $user->user_email


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

This function `directorist_password_reset_url()` is used by many of our resources like themes and extensions. When users are updating the core plugin first they get a fatal error for type casting of the `$user` variable

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
