### PR TITLE
fixed short video display issue in widget video area

### DIFF
--- a/templates/widgets/listing-video.php
+++ b/templates/widgets/listing-video.php
@@ -2,11 +2,13 @@
 /**
  * @author  wpWax
  * @since   7.3.0
- * @version 7.3.1
+ * @version 7.8.0
  */
 
+use \Directorist\Helper;
+
 if ( ! defined( 'ABSPATH' ) ) exit;
-$videourl   = ! empty( $videourl ) ? esc_attr( ATBDP()->atbdp_parse_videos( $videourl ) ) : '';
+$videourl   = ! empty( $videourl ) ? Helper::parse_video( $videourl ) : '';
 ?>
 
 <div class="atbdp">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. https://prnt.sc/e8XhjG-MIhBE
2. Removed esc_attr too because we use esc_url when printing
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
