### PR TITLE
Deprecated function

### DIFF
--- a/directorist-base.php
+++ b/directorist-base.php
@@ -681,9 +681,8 @@ final class Directorist_Base
 	public function atbdp_parse_videos( $url ) {	
 		$helper = new \Directorist\Helper();
 		_deprecated_function( __METHOD__, '7.8.0', $helper->parse_video( $url ) );
-		// Return
+		
 		return $helper->parse_video( $url );
-
 	}
 
 	public function atbdp_body_class($c_classes)

--- a/directorist-base.php
+++ b/directorist-base.php
@@ -671,18 +671,17 @@ final class Directorist_Base
 	/**
 	 * Deprecated: 7.8.0
 	 * 
-	 * This function is deprecated since version 7.8.0. Please use parseVideo() instead.
+	 * This function is deprecated since version 7.8.0. Please use parse_video() instead.
 	 *
 	 * @param string $url The URL to parse for videos.
 	 * @return mixed The parsed video URL.
 	 *
-	 * @deprecated Use parseVideo() for video parsing.
+	 * @deprecated Use parse_video() for video parsing.
 	 */
 	public function atbdp_parse_videos( $url ) {	
-		$helper = new \Directorist\Helper();
-		_deprecated_function( __METHOD__, '7.8.0', $helper->parse_video( $url ) );
-		
-		return $helper->parse_video( $url );
+		_deprecated_function( __METHOD__, '7.8.0', 'Directorist\Helper::parse_video()' );
+
+		return \Directorist\Helper::parse_video( $url );
 	}
 
 	public function atbdp_body_class($c_classes)

--- a/directorist-base.php
+++ b/directorist-base.php
@@ -669,35 +669,20 @@ final class Directorist_Base
 	}
 
 	/**
-	 * Parse the video URL and determine it's valid embeddable URL for usage.
+	 * Deprecated: 7.8.0
+	 * 
+	 * This function is deprecated since version 7.8.0. Please use parseVideo() instead.
+	 *
+	 * @param string $url The URL to parse for videos.
+	 * @return mixed The parsed video URL.
+	 *
+	 * @deprecated Use parseVideo() for video parsing.
 	 */
-	public function atbdp_parse_videos($url)
-	{
-		$embeddable_url = '';
-		// Check for YouTube
-		$is_youtube = preg_match('/youtu\.be/i', $url) || preg_match('/youtube\.com\/watch/i', $url);
-
-		if ($is_youtube) {
-			$pattern = '/^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#\&\?]*).*/';
-			preg_match($pattern, $url, $matches);
-			if (count($matches) && strlen($matches[7]) == 11) {
-				$embeddable_url = 'https://www.youtube.com/embed/' . $matches[7];
-			}
-		}
-
-		// Check for Vimeo
-		$is_vimeo = preg_match('/vimeo\.com/i', $url);
-
-		if ($is_vimeo) {
-			$pattern = '/\/\/(www\.)?vimeo.com\/(\d+)($|\/)/';
-			preg_match($pattern, $url, $matches);
-			if (count($matches)) {
-				$embeddable_url = 'https://player.vimeo.com/video/' . $matches[2];
-			}
-		}
-
+	public function atbdp_parse_videos( $url ) {	
+		$helper = new \Directorist\Helper();
+		_deprecated_function( __METHOD__, '7.8.0', $helper->parse_video( $url ) );
 		// Return
-		return $embeddable_url;
+		return $helper->parse_video( $url );
 
 	}
 

--- a/templates/single/fields/video.php
+++ b/templates/single/fields/video.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.7
- * @version 6.7
+ * @version 7.8
  */
 
 use \Directorist\Helper;
@@ -10,4 +10,4 @@ use \Directorist\Helper;
 if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
 
-<iframe class="directorist-embaded-video embed-responsive-item" src="<?php echo esc_attr( Helper::parse_video( $value ) ); ?>" allowfullscreen></iframe>
+<iframe class="directorist-embaded-video embed-responsive-item" src="<?php echo esc_url( Helper::parse_video( $value ) ); ?>" allowfullscreen></iframe>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Deprecated atbdp_parse_videos method from Directorist_Base class
2. Use ecs_url on single listing video field
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
