### PR TITLE
Texarea Height Issue - Fixed

### DIFF
--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -9006,7 +9006,8 @@ for shortable field*/
 }
 .directorist-form-group textarea,
 .directorist-form-group textarea.directorist-form-element {
-  min-height: 120px;
+  min-height: unset;
+  height: auto;
 }
 
 .directorist-form-group .directorist-form-element {

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -9006,7 +9006,8 @@ for shortable field*/
 }
 .directorist-form-group textarea,
 .directorist-form-group textarea.directorist-form-element {
-  min-height: 120px;
+  min-height: unset;
+  height: auto;
 }
 
 .directorist-form-group .directorist-form-element {

--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -7900,7 +7900,8 @@ p.atbd-min {
 }
 .directorist-form-group textarea,
 .directorist-form-group textarea.directorist-form-element {
-  min-height: 120px;
+  min-height: unset;
+  height: auto;
 }
 
 .directorist-form-group .directorist-form-element {

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -7892,7 +7892,8 @@ p.atbd-min {
 }
 .directorist-form-group textarea,
 .directorist-form-group textarea.directorist-form-element {
-  min-height: 120px;
+  min-height: unset;
+  height: auto;
 }
 
 .directorist-form-group .directorist-form-element {

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -7900,7 +7900,8 @@ p.atbd-min {
 }
 .directorist-form-group textarea,
 .directorist-form-group textarea.directorist-form-element {
-  min-height: 120px;
+  min-height: unset;
+  height: auto;
 }
 
 .directorist-form-group .directorist-form-element {

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -7892,7 +7892,8 @@ p.atbd-min {
 }
 .directorist-form-group textarea,
 .directorist-form-group textarea.directorist-form-element {
-  min-height: 120px;
+  min-height: unset;
+  height: auto;
 }
 
 .directorist-form-group .directorist-form-element {

--- a/assets/src/scss/component/_form.scss
+++ b/assets/src/scss/component/_form.scss
@@ -4,7 +4,8 @@
 
     textarea,
     textarea.directorist-form-element {
-        min-height: 120px;
+        min-height: unset;
+        height: auto;
     }
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
**Custom field> Textarea row limit at add listing form is not working -** 

<img width="706" alt="image" src="https://github.com/sovware/directorist/assets/99108560/45348e84-41e9-4237-8f57-64edc5fe53fc">

<img width="701" alt="image" src="https://github.com/sovware/directorist/assets/99108560/ccd5628d-019e-4bca-8951-206e4319a9e9">


## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
