### PR TITLE
add affiliate id referance in promo links

### DIFF
--- a/includes/classes/class-upgrade.php
+++ b/includes/classes/class-upgrade.php
@@ -58,12 +58,15 @@ class ATBDP_Upgrade
 		$display        = ! empty( $response_body->promo_2_display ) ? $response_body->promo_2_display : '';
 		$text           = ! empty( $response_body->promo_2_text ) ? $response_body->promo_2_text : '';
 		$version        = ! empty( $response_body->promo_2_version ) ? $response_body->promo_2_version : '';
+		$link           = ! empty( $response_body->get_now_button_link ) ? self::promo_link( $response_body->get_now_button_link ) : '';
 
 		$closed_version = get_user_meta( get_current_user_id(), 'directorist_promo2_closed_version', true );
 
 		if ( !$display || $version == $closed_version || !$text ) {
 			return;
 		}
+
+		$text = str_replace( '{{link}}', $link, $text );
 
 		$dismiss_url = add_query_arg(
 			array(
@@ -164,6 +167,14 @@ class ATBDP_Upgrade
 			update_user_meta( get_current_user_id(), 'directorist_promo2_closed_version', directorist_clean( wp_unslash( $_GET['directorist_promo2_closed_version'] ) ) );
 		}
 
+	}
+
+	public static function promo_link( $link ) {
+		if( defined( 'DIRECTORIST_AFFLILIATE_ID' ) && DIRECTORIST_AFFLILIATE_ID !== null ) {
+			$link = $link . "ref/" . DIRECTORIST_AFFLILIATE_ID;
+		}
+
+		return $link;
 	}
 
 }

--- a/views/admin-templates/admin-promo-banner.php
+++ b/views/admin-templates/admin-promo-banner.php
@@ -17,10 +17,10 @@ if( ! $display_promo || ( $directorist_promo_closed && ( $directorist_promo_clos
 $banner_title        = ! empty( $response_body->banner_title ) ? $response_body->banner_title : '';
 $banner_description  = ! empty( $response_body->banner_description ) ? $response_body->banner_description : '';
 $sale_button_text    = ! empty( $response_body->sale_button_text ) ? $response_body->sale_button_text : '';
-$sale_button_link    = ! empty( $response_body->sale_button_link ) ? $response_body->sale_button_link : '';
+$sale_button_link    = ! empty( $response_body->sale_button_link ) ? ATBDP_Upgrade::promo_link( $response_body->sale_button_link ) : '';
 $offer_lists         = ! empty( $response_body->offer_lists ) ? $response_body->offer_lists : [];
 $get_now_button_text = ! empty( $response_body->get_now_button_text ) ? $response_body->get_now_button_text : '';
-$get_now_button_link = ! empty( $response_body->get_now_button_link ) ? $response_body->get_now_button_link : '';
+$get_now_button_link = ! empty( $response_body->get_now_button_link ) ? ATBDP_Upgrade::promo_link( $response_body->get_now_button_link ) : '';
 
 $url_args = [
     'close-directorist-promo-version' => $promo_version,

--- a/views/admin-templates/theme-extensions/all-themes-extensions.php
+++ b/views/admin-templates/theme-extensions/all-themes-extensions.php
@@ -5,7 +5,9 @@
     <div class="et-column">
         <h3><?php esc_html_e( 'Extensions', 'directorist' ) ?></h3>
 
-        <?php foreach( $args['extensions_promo_list'] as $extension_key => $extension ) : ?>
+        <?php foreach( $args['extensions_promo_list'] as $extension_key => $extension ) :
+            $link = ATBDP_Upgrade::promo_link( $extension['link'] );
+            ?>
         <div class="et-card">
             <div class="et-card__image">
                 <img src="<?php echo esc_url( $extension['thumbnail'] ); ?>" alt="">
@@ -14,8 +16,8 @@
                 <h3><?php echo esc_html( $extension['name'] ); ?></h3>
                 <p><?php echo esc_html( $extension['description'] ); ?></p>
                 <ul>
-                    <li><a href="<?php echo esc_url( $extension['link'] ); ?>" class="et-card__btn et-card__btn--primary"><?php esc_html_e( 'View Details', 'directorist' ); ?></a></li>
-                    <li><a href="<?php echo esc_url( $extension['link'] ); ?>" class="et-card__btn et-card__btn--secondary"><?php esc_html_e( 'Get It Now', 'directorist' ); ?></a></li>
+                    <li><a href="<?php echo esc_url( $link ); ?>" class="et-card__btn et-card__btn--primary"><?php esc_html_e( 'View Details', 'directorist' ); ?></a></li>
+                    <li><a href="<?php echo esc_url( $link ); ?>" class="et-card__btn et-card__btn--secondary"><?php esc_html_e( 'Get It Now', 'directorist' ); ?></a></li>
                 </ul>
             </div>
         </div><!-- ends: .et-card -->
@@ -27,7 +29,9 @@
     <div class="et-column">
         <h3><?php esc_html_e( 'Themes', 'directorist' ) ?></h3>
 
-        <?php foreach( $args['themes_promo_list'] as $theme_key => $theme ) : ?>
+        <?php foreach( $args['themes_promo_list'] as $theme_key => $theme ) : 
+            $link = ATBDP_Upgrade::promo_link( $theme['link'] );
+            ?>
         <div class="et-card">
             <div class="et-card__image">
                 <img src="<?php echo esc_url( $theme['thumbnail'] ); ?>" alt="">
@@ -36,8 +40,8 @@
                 <h3><?php echo esc_html( $theme['name'] ); ?></h3>
                 <p><?php echo esc_html( $theme['description'] ); ?></p>
                 <ul>
-                    <li><a href="<?php echo esc_url( $theme['link'] ); ?>" class="et-card__btn et-card__btn--primary"><?php esc_html_e( 'View Details', 'directorist' ) ?></a></li>
-                    <li><a href="<?php echo esc_url( $theme['link'] ); ?>" class="et-card__btn et-card__btn--secondary"><?php esc_html_e( 'Get It Now', 'directorist' ) ?></a></li>
+                    <li><a href="<?php echo esc_url( $link ); ?>" class="et-card__btn et-card__btn--primary"><?php esc_html_e( 'View Details', 'directorist' ) ?></a></li>
+                    <li><a href="<?php echo esc_url( $link ); ?>" class="et-card__btn et-card__btn--secondary"><?php esc_html_e( 'Get It Now', 'directorist' ) ?></a></li>
                 </ul>
             </div>
         </div><!-- ends: .et-card -->


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [x] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Add affiliate referrer id on

- Promo banner links in Settings and Builder page
- Themes & Extension page promo links

To check this please try as a free new user defining the const in the theme's functions.php file

`DIRECTORIST_AFFLILIATE_ID` after_setup_theme hook would be great in defining the const with a random number

Expected output: https://prnt.sc/f7m91A9AiY-l

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
