### PR TITLE
Fix term directory override issue on listings import

### DIFF
--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -166,25 +166,28 @@
                                 continue;
                             }
 
-                            if ('category' == $taxonomy) {
+                            if ( 'category' === $taxonomy ) {
                                 $taxonomy = ATBDP_CATEGORY;
-                            }elseif ('location' == $taxonomy) {
+                            } elseif ( 'location' === $taxonomy ) {
                                 $taxonomy = ATBDP_LOCATION;
-                            }else{
+                            } else {
                                 $taxonomy = ATBDP_TAGS;
                             }
 
                             $term_ids = array();
                             $multiple = $terms > 0;
 
-                            foreach( $terms as $term ) {
+                            foreach ( $terms as $term ) {
 								$term_id = $this->get_or_create_term_id( $term, $taxonomy );
 
 								if ( empty( $term_id ) ) {
 									continue;
 								}
 
-                                update_term_meta( $term_id, '_directory_type', [ $directory_type ] );
+								if ( $taxonomy === ATBDP_CATEGORY || $taxonomy === ATBDP_LOCATION ) {
+									directorist_update_term_directory( $term_id, array( $directory_type ), true );
+								}
+
                                 $term_ids[] = $term_id;
                             }
 

--- a/includes/directorist-directory-functions.php
+++ b/includes/directorist-directory-functions.php
@@ -147,3 +147,44 @@ function directorist_set_listing_directory( $listing_id, $directory_id ) {
 
 	return true;
 }
+
+function directorist_update_term_directory( $term_id, array $directory_ids = array(), $append = false ) {
+	if ( empty( $directory_ids ) ) {
+		return;
+	}
+
+	$directory_ids = wp_parse_id_list( $directory_ids );
+
+	if ( $append ) {
+		$old_directory_ids = directorist_get_term_directory( $term_id );
+		$directory_ids     = array_unique( array_merge( $old_directory_ids, $directory_ids ) );
+	}
+
+	update_term_meta( $term_id, '_directory_type', $directory_ids );
+}
+
+function directorist_update_location_directory( $location_id, array $directory_ids = array(), $append = false) {
+	directorist_update_term_directory( $location_id, $directory_ids, $append );
+}
+
+function directorist_update_category_directory( $location_id, array $directory_ids = array(), $append = false) {
+	directorist_update_term_directory( $location_id, $directory_ids, $append );
+}
+
+function directorist_get_term_directory( $term_id ) {
+	$directories = (array) get_term_meta( $term_id, '_directory_type', true );
+
+	if ( empty( $directories ) ) {
+		return array();
+	}
+
+	return wp_parse_id_list( $directories );
+}
+
+function directorist_get_location_directory( $location_id ) {
+	return directorist_get_term_directory( $location_id );
+}
+
+function directorist_get_category_directory( $category_id ) {
+	return directorist_get_term_directory( $category_id );
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Any linked issues
Fixes https://wordpress.org/support/topic/csv-import-removes-previous-directory-location-associations/

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
