### PR TITLE
removed esc_url from advance-search-form

### DIFF
--- a/templates/archive/advance-search-form.php
+++ b/templates/archive/advance-search-form.php
@@ -9,7 +9,7 @@ use \Directorist\Helper;
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
-<form action="<?php esc_url( atbdp_search_result_page_link() ); ?>" class="directorist-search-form directorist-advanced-search">
+<form action="<?php atbdp_search_result_page_link(); ?>" class="directorist-search-form directorist-advanced-search">
 	<div class="directorist-search-form-box directorist-search-form__box">
 		<div class="directorist-advanced-filter__top">
 			<h2 class="directorist-advanced-filter__title"><?php esc_html_e( 'Filters', 'directorist' ); ?></h2>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.
2.
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
