### PR TITLE
Fix category dependent required field validation

### DIFF
--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -754,7 +754,7 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 		public static function validate_field( $field, $posted_data ) {
 			$should_validate = (bool) apply_filters( 'atbdp_add_listing_form_validation_logic', true, $field->get_props(), $posted_data );
 
-			if ( $field->is_category_only() && ! in_array( $field->get_assigned_category(), self::$selected_categories, true ) ) {
+			if ( is_null( self::$selected_categories ) || ( $field->is_category_only() && ! in_array( $field->get_assigned_category(), self::$selected_categories, true ) ) ) {
 				$should_validate = false;
 			}
 

--- a/includes/directorist-directory-functions.php
+++ b/includes/directorist-directory-functions.php
@@ -63,7 +63,9 @@ function directorist_get_listing_form_field( $directory_id, $field_key = '' ) {
 		return array();
 	}
 
-	return directorist_get_listing_form_fields( $directory_id )[ $field_key ] ?: array();
+	$form_fields = directorist_get_listing_form_fields( $directory_id );
+
+	return empty( $form_fields[ $field_key ] ) ? array() : $form_fields[ $field_key ];
 }
 
 function directorist_get_listing_form_category_field( int $directory_id ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
Where there are required custom fields assigned to a specific category but unfortunately the category field is not added or missing from the add listing form then the field required error is displayed to the user.

## Any linked issues
Fixes https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/9622566

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
