### PR TITLE
fix duplicate meta description with Yoast"

### DIFF
--- a/includes/classes/class-seo.php
+++ b/includes/classes/class-seo.php
@@ -54,7 +54,6 @@ if ( ! class_exists( 'ATBDP_SEO' ) ) :
 			add_filter( 'single_post_title', array( $this, 'update_taxonomy_single_page_title' ), 10, 2 );
 			add_filter( 'pre_get_document_title', array($this, 'atbdp_custom_page_title'), 10 );
 
-			add_action('wp_head', array($this, 'atbdp_add_meta_keywords'), 10, 2);
 			add_filter('wp_title', array($this, 'atbdp_custom_page_title'), 10, 2);
 
 			add_filter('wpseo_title', array($this, 'wpseo_title'));


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Activate the Yoast SEO plugin
2. Go to the single category or location page
3. Check the page source

## Any linked issues
Fixes # https://tasks.hubstaff.com/app/organizations/37274/projects/338303/tasks/9574288

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
