### PR TITLE
fix: atbdp_format_amount filter

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -101,7 +101,7 @@ function atbdp_get_payment_bulk_actions()
  */
 function atbdp_format_amount( $amount, $decimals = true, $currency_settings = array() ) {
 
-    return number_format_i18n( apply_filters( 'atbdp_format_amount', (float) $amount, (float) $amount, $decimals, $currency_settings ), 2 );
+    return apply_filters( 'atbdp_format_amount', number_format_i18n( ( float ) $amount, 2 ), $amount, $decimals, $currency_settings );
 
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. This "atbdp_format_amount" filter hook was not working because of the wrong placement. Any changes developed by the filter were overrode because of this wrong placement of the filter hook.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
