### PR TITLE
Fix max image limit validation issue when value is empty or zero

### DIFF
--- a/includes/fields/class-directorist-image-upload-field.php
+++ b/includes/fields/class-directorist-image-upload-field.php
@@ -37,7 +37,7 @@ class Image_Upload_Field extends Base_Field {
 			return false;
 		}
 
-		if ( ( count( $old_images ) + count( $new_images ) ) > $this->get_total_upload_limit() ) {
+		if ( $this->get_total_upload_limit() !== 0 && ( ( count( $old_images ) + count( $new_images ) ) > $this->get_total_upload_limit() ) ) {
 			$this->add_error( sprintf(
 				_n( '%s image allowed only.', '%s images allowed only.', $this->get_total_upload_limit(), 'directorist' ),
 				$this->get_total_upload_limit()


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
How to reproduce the issue or how to test the changes
<img width="405" alt="image" src="https://github.com/sovware/directorist/assets/10244644/85aa2035-fb6d-458e-97a4-15474cff4c9d">

Builder:
1. Set "Max Image Limit" to zero or keep it empty.
2. Set the field not required.

Frontend:
1. Submit the form selecting at least 1 image.

## Any linked issues
Fixes [46045 - Add Listing Issue]

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
