### PR TITLE
Add new hook: single listing slider image size

### DIFF
--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -491,9 +491,11 @@ class Directorist_Single_Listing {
 		$type          = get_post_meta( get_the_ID(), '_directory_type', true );
 		$default_image = Helper::default_preview_image_src( $type );
 
+		$image_size = apply_filters( 'directorist_single_listing_slider_image_size', 'large' );
+
 		// Get the preview images
 		$preview_img_id   = get_post_meta( $listing_id, '_listing_prv_img', true);
-		$preview_img_link = ! empty($preview_img_id) ? atbdp_get_image_source( $preview_img_id, 'large' ) : '';
+		$preview_img_link = ! empty($preview_img_id) ? atbdp_get_image_source( $preview_img_id, $image_size ) : '';
 		$preview_img_alt  = get_post_meta($preview_img_id, '_wp_attachment_image_alt', true);
 		$preview_img_alt  = ( ! empty( $preview_img_alt )  ) ? $preview_img_alt : get_the_title( $preview_img_id );
 
@@ -508,7 +510,7 @@ class Directorist_Single_Listing {
 
 			$image_links[] = [
 				'alt' => ( ! empty( $alt )  ) ? $alt : $listing_title,
-				'src' => atbdp_get_image_source( $img_id, 'large' ),
+				'src' => atbdp_get_image_source( $img_id, $image_size ),
 			];
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Add a new filter hook to manipulate the single listing slider image size -
"directorist_single_listing_slider_image_size"

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
