### PR TITLE
Add new filter hook: directorist archive single listing url

### DIFF
--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -1571,7 +1571,7 @@ class Directorist_Listings {
 
 		public function loop_get_title() {
 			if ( ! $this->disable_single_listing ) {
-				$title = sprintf('<a href="%s"%s>%s</a>', $this->loop['permalink'], $this->loop_link_attr(), $this->loop['title']);
+				$title = sprintf('<a href="%s"%s>%s</a>', apply_filters( 'directorist_archive_single_listing_url', $this->loop['permalink'], $this->loop['id'], 'title' ), $this->loop_link_attr(), $this->loop['title']);
 			}
 			else {
 				$title = $this->loop['title'];

--- a/templates/archive/fields/excerpt.php
+++ b/templates/archive/fields/excerpt.php
@@ -15,7 +15,7 @@ if ( !$value ) {
 <p>
 	<?php echo esc_html( wp_trim_words( $value, (int) $data['words_limit'] ) );
 	if ( $data['show_readmore'] ) {
-		printf( '<a href="%s"> %s</a>', esc_url( $listings->loop['permalink'] ), esc_html( $data['show_readmore_text'] ) );
+		printf( '<a href="%s"> %s</a>', esc_url( apply_filters( 'directorist_archive_single_listing_url', $listings->loop['permalink'], $listings->loop['id'], 'excerpt' ) ), esc_html( $data['show_readmore_text'] ) );
 	}
 	?>
 </p>

--- a/templates/archive/fields/thumb-card.php
+++ b/templates/archive/fields/thumb-card.php
@@ -71,7 +71,7 @@ switch ($image_size) {
 }
 
 
-$link_start = '<a href="'.esc_url( $listings->loop['permalink'] ).'">';
+$link_start = '<a href="'.esc_url( apply_filters( 'directorist_archive_single_listing_url', $listings->loop['permalink'], $listings->loop['id'], 'thumbnail' ) ).'">';
 $link_end   = '</a>';
 
 if (!$listings->disable_single_listing) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

New filter hook added - directorist_archive_single_listing_url

**Parameters:**
$permalink - Url of the single listing
$listing_id - Single listing id
$location - Location of the link - thumbnail | title | excerpt

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
