### PR TITLE
Fixed phone number plus prefix missing issue

### DIFF
--- a/includes/class-helper.php
+++ b/includes/class-helper.php
@@ -329,36 +329,29 @@ class Helper {
 		return $price;
 	}
 
-	public static function formatted_tel( $tel = '', $echo = true ) {
-		$tel = preg_replace( '/\D/', '', $tel );
+	public static function formatted_tel( $tel_number = '', $echo = true ) {
+		$tel_number = preg_replace( '/[^\d\+]/', '', $tel_number );
 
-		if ( !$echo ) {
-			return $tel;
+		if ( ! $echo ) {
+			return $tel_number;
 		}
-		else {
-			echo esc_html( $tel );
-		}
+
+		echo esc_html( $tel_number );
 	}
 
 	public static function phone_link( $args ) {
-
-		$defaults = array(
+		$args = array_merge( array(
 			'number'    => '',
 			'whatsapp'  => false,
-		);
+		), $args );
 
-		$args = wp_parse_args( $args, $defaults );
-
-		$num = self::formatted_tel( $args['number'], false );
+		$number = self::formatted_tel( $args['number'], false );
 
 		if ( $args['whatsapp'] ) {
-			$result = sprintf( 'https://wa.me/%s', $num );
-		}
-		else {
-			$result = sprintf( 'tel:%s', $num );
+			return sprintf( 'https://wa.me/%s', $number );
 		}
 
-		return $result;
+		return sprintf( 'tel:%s', $number );
 	}
 
 	public static function user_info( $user_id_or_obj, $meta ) {

--- a/templates/single/fields/phone.php
+++ b/templates/single/fields/phone.php
@@ -13,10 +13,9 @@ $phone_args = array(
 	'number'    => $value,
 	'whatsapp'  => $listing->has_whatsapp( $data ),
 );
+
 ?>
-
 <div class="directorist-single-info directorist-single-info-phone">
-
 	<div class="directorist-single-info__label">
 		<span class="directorist-single-info__label-icon"><?php directorist_icon( $icon );?></span>
 		<span class="directorist-single-info__label--text"><?php echo esc_html( $data['label'] ); ?></span>
@@ -25,5 +24,4 @@ $phone_args = array(
 	<div class="directorist-single-info__value">
 		<a href="<?php echo esc_url( Helper::phone_link( $phone_args ) ); ?>"><?php echo esc_html( $value ); ?></a>
 	</div>
-
 </div>

--- a/templates/single/fields/phone2.php
+++ b/templates/single/fields/phone2.php
@@ -13,10 +13,9 @@ $phone_args = array(
 	'number'    => $value,
 	'whatsapp'  => $listing->has_whatsapp( $data ),
 );
+
 ?>
-
 <div class="directorist-single-info directorist-single-info-phone2">
-
 	<div class="directorist-single-info__label">
 		<span class="directorist-single-info__label-icon"><?php directorist_icon( $icon );?></span>
 		<span class="directorist-single-info__label--text"><?php echo esc_html( $data['label'] ); ?></span>
@@ -25,5 +24,4 @@ $phone_args = array(
 	<div class="directorist-single-info__value">
 		<a href="<?php echo esc_url( Helper::phone_link( $phone_args ) ); ?>"><?php echo esc_html( $value ); ?></a>
 	</div>
-
 </div>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
How to reproduce the issue or how to test the changes

1. Add a phone number field in the add listing and setup single view accordingly
2. Add any phone number with + prefix, for example +88017111111
3. Check the single listing view, you'll find the + is missing

## Any linked issues
N/A

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
