### PR TITLE
fix: single taxonomy archive page title issue for yoast seo plugin

### DIFF
--- a/includes/classes/class-seo.php
+++ b/includes/classes/class-seo.php
@@ -410,6 +410,10 @@ if ( ! class_exists( 'ATBDP_SEO' ) ) :
                             if (array_key_exists('wpseo_focuskw', $meta['at_biz_dir-category'][$term->term_id])) {
                                 $replacements['%%term_title%%'] = $meta['at_biz_dir-category'][$term->term_id]['wpseo_focuskw'];
                             }
+
+                            if (array_key_exists('wpseo_title', $meta['at_biz_dir-category'][$term->term_id]) && !empty($meta['at_biz_dir-category'][$term->term_id]['wpseo_title'])) {
+                                $title_template = $meta['at_biz_dir-category'][$term->term_id]['wpseo_title'];
+                            }
                         }
                     }
                 }
@@ -437,6 +441,10 @@ if ( ! class_exists( 'ATBDP_SEO' ) ) :
                             if (array_key_exists('wpseo_focuskw', $meta['at_biz_dir-location'][$term->term_id])) {
                                 $replacements['%%term_title%%'] = $meta['at_biz_dir-location'][$term->term_id]['wpseo_focuskw'];
                             }
+
+                            if (array_key_exists('wpseo_title', $meta['at_biz_dir-location'][$term->term_id]) && !empty($meta['at_biz_dir-location'][$term->term_id]['wpseo_title'])) {
+                                $title_template = $meta['at_biz_dir-location'][$term->term_id]['wpseo_title'];
+                            }
                         }
                     }
                 }
@@ -463,6 +471,10 @@ if ( ! class_exists( 'ATBDP_SEO' ) ) :
 
                             if (array_key_exists('wpseo_focuskw', $meta['at_biz_dir-tags'][$term->term_id])) {
                                 $replacements['%%term_title%%'] = $meta['at_biz_dir-tags'][$term->term_id]['wpseo_focuskw'];
+                            }
+
+                            if (array_key_exists('wpseo_title', $meta['at_biz_dir-tags'][$term->term_id]) && !empty($meta['at_biz_dir-tags'][$term->term_id]['wpseo_title'])) {
+                                $title_template = $meta['at_biz_dir-tags'][$term->term_id]['wpseo_title'];
                             }
                         }
                     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
When you are using Yoast SEO plugin, custom changes from the single taxonomy title is not working as expected -
https://prnt.sc/dHY25yXNQgLI
https://prnt.sc/vUrtQ1a_fKw5

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
