### PR TITLE
Fix widget checkbox boolean value

### DIFF
--- a/includes/widgets/all-categories.php
+++ b/includes/widgets/all-categories.php
@@ -75,18 +75,22 @@ class All_Categories extends \WP_Widget {
             'immediate_category' => [
 				'label'   => esc_html__( 'Show all the top-level categories only', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'hide_empty' => [
 				'label'   => esc_html__( 'Hide empty categories', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'show_count' => [
 				'label'   => esc_html__( 'Display listing counts', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'single_only' => [
 				'label'   => esc_html__( 'Display only on single listing', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
         ];
 

--- a/includes/widgets/all-categories.php
+++ b/includes/widgets/all-categories.php
@@ -171,14 +171,10 @@ class All_Categories extends \WP_Widget {
 	}
 
     public function directorist_categories_list( $settings ) {
-
-
-        if( $settings['immediate_category'] ) {
-
-            if( $settings['term_id'] > $settings['parent'] && ! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
-                return;
-            }
-
+        if ( $settings['immediate_category'] &&
+			( $settings['term_id'] > $settings['parent'] ) &&
+			! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
+			return;
         }
 
         $args = array(
@@ -193,59 +189,47 @@ class All_Categories extends \WP_Widget {
         );
 
         $terms = get_terms( $args );
-        $parent = $args['parent'];
-        $child_class = !empty($parent) ? 'atbdp_child_category' : 'atbdp_parent_category';
-        $html = '';
-        if( count( $terms ) > 0 ) {
-            $i = 1;
-            $html .= '<ul class="' .$child_class. '">';
-            foreach( $terms as $term ) {
-				$settings['term_id'] = $term->term_id;
-                $child_category = get_term_children($term->term_id,ATBDP_CATEGORY);
-                $plus_icon = (!empty($child_category) && empty($parent) )? directorist_icon( 'las la-plus', false ) : '';
-                $icon = get_term_meta($term->term_id,'category_icon',true);
-                $child_icon = empty($parent)  ? directorist_icon( $icon, false ) : '';
 
-                $count = 0;
-                if( ! empty( $settings['hide_empty'] ) || ! empty( $settings['show_count'] ) ) {
-                    $count = atbdp_listings_count_by_category( $term->term_id );
+		if ( is_wp_error( $terms ) ) {
+			return;
+		}
 
-                    if( ! empty( $settings['hide_empty'] ) && 0 == $count ) continue;
-                }
+        $parent      = $args['parent'];
+        $child_class = ! empty( $parent ) ? 'atbdp_child_category' : 'atbdp_parent_category';
+        $html        = '';
 
-                $html .= '<li>';
-                $html .= '<a href="' . \ATBDP_Permalink::atbdp_get_category_page( $term ) . '">'. $child_icon .'';
-                $html .= $term->name;
-                if( ! empty( $settings['show_count'] ) ) {
-                    $expired_listings = atbdp_get_expired_listings(ATBDP_CATEGORY, $term->term_id);
-                    $number_of_expired = $expired_listings->post_count;
-                    $number_of_expired = !empty($number_of_expired)?$number_of_expired:'0';
-                    $totat = ($count)?($count-$number_of_expired):$count;
-                    $html .= ' (' . $totat . ')';
-                }
-                $html .= '</a>'. $plus_icon . '';
-                $html .= $this->directorist_categories_list( $settings );
-                $html .= '</li>';
-                if(!empty($args['number'])) {
-                    if( $i++ == $args['number'] ) break;
-                }
-            }
-            $html .= '</ul>';
+		$html .= '<ul class="' .$child_class. '">';
 
-        }
+		foreach( $terms as $term ) {
+			$settings['term_id'] = $term->term_id;
+			$child_category = get_term_children($term->term_id,ATBDP_CATEGORY);
+			$plus_icon = (!empty($child_category) && empty($parent) )? directorist_icon( 'las la-plus', false ) : '';
+			$icon = get_term_meta($term->term_id,'category_icon',true);
+			$child_icon = empty($parent)  ? directorist_icon( $icon, false ) : '';
+
+			$html .= '<li>';
+			$html .= '<a href="' . \ATBDP_Permalink::atbdp_get_category_page( $term ) . '">'. $child_icon .'';
+			$html .= $term->name;
+
+			if ( ! empty( $settings['show_count'] ) ) {
+				$html .= ' (' . $term->count . ')';
+			}
+
+			$html .= '</a>'. $plus_icon . '';
+			$html .= $this->directorist_categories_list( $settings );
+			$html .= '</li>';
+		}
+
+		$html .= '</ul>';
 
         return $html;
-
     }
 
     public function dropdown_categories( $settings, $prefix = '' ) {
-
-        if( $settings['immediate_category'] ) {
-
-            if( $settings['term_id'] > $settings['parent'] && ! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
-                return;
-            }
-
+        if ( $settings['immediate_category'] &&
+			( $settings['term_id'] > $settings['parent'] ) &&
+			! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
+			return;
         }
 
         $term_slug = get_query_var( ATBDP_CATEGORY );
@@ -262,35 +246,26 @@ class All_Categories extends \WP_Widget {
 
         $terms = get_terms( $args );
 
+		if ( is_wp_error( $terms ) ) {
+			return;
+		}
+
         $html = '';
 
-        if( count( $terms ) > 0 ) {
-            $i = 1;
-            foreach( $terms as $term ) {
-                $settings['term_id'] = $term->term_id;
+		foreach( $terms as $term ) {
+			$settings['term_id'] = $term->term_id;
 
-                $count = 0;
-                if( ! empty( $settings['hide_empty'] ) || ! empty( $settings['show_count'] ) ) {
-                    $count = atbdp_listings_count_by_category( $term->term_id );
+			$html .= sprintf( '<option value="%s" %s>', $term->term_id, selected( $term->term_id, $term_slug, false ) );
+			$html .= $prefix . $term->name;
 
-                    if( ! empty( $settings['hide_empty'] ) && 0 == $count ) continue;
-                }
+			if ( ! empty( $settings['show_count'] ) ) {
+				$html .= ' (' . $term->count . ')';
+			}
 
-                $html .= sprintf( '<option value="%s" %s>', $term->term_id, selected( $term->term_id, $term_slug, false ) );
-                $html .= $prefix . $term->name;
-                if( ! empty( $settings['show_count'] ) ) {
-                    $html .= ' (' . $count . ')';
-                }
-                //$html .= $this->dropdown_locations( $settings, $prefix . '&nbsp;&nbsp;&nbsp;' );
-                $html .= '</option>';
-                if(!empty($args['number'])) {
-                    if( $i++ == $args['number'] ) break;
-                }
-            }
-
-        }
+			//$html .= $this->dropdown_locations( $settings, $prefix . '&nbsp;&nbsp;&nbsp;' );
+			$html .= '</option>';
+		}
 
         return $html;
-
     }
 }

--- a/includes/widgets/all-locations.php
+++ b/includes/widgets/all-locations.php
@@ -29,10 +29,10 @@ class All_Locations extends \WP_Widget {
             'order_by'              => 'id',
             'order'                 => 'asc',
             'max_number'            => '',
-            'immediate_category'    => '',
-            'hide_empty'            => '',
-            'show_count'            => '',
-            'single_only'           => '',
+            'immediate_category'    => 1,
+            'hide_empty'            => 1,
+            'show_count'            => 1,
+            'single_only'           => 1,
 		];
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -100,61 +100,65 @@ class All_Locations extends \WP_Widget {
 		$instance['display_as']         = ! empty( $new_instance['display_as'] ) ? sanitize_text_field( $new_instance['display_as'] ) : 'list';
         $instance['order_by']           = ! empty( $new_instance['order_by'] ) ? sanitize_text_field( $new_instance['order_by'] ) : 'id';
         $instance['order']              = ! empty( $new_instance['order'] ) ? sanitize_text_field( $new_instance['order'] ) : 'asc';
-        $instance['immediate_category'] = ! empty( $new_instance['immediate_category'] ) ? 1 : 0;
-        $instance['hide_empty']         = ! empty( $new_instance['hide_empty'] ) ? 1 : 0;
-        $instance['show_count']         = ! empty( $new_instance['show_count'] ) ? 1 : 0;
-        $instance['single_only']        = ! empty( $new_instance['single_only'] ) ? 1 : 0;
+        $instance['immediate_category'] = isset( $new_instance['immediate_category'] ) ? 1 : 0;
+        $instance['hide_empty']         = isset( $new_instance['hide_empty'] ) ? 1 : 0;
+        $instance['show_count']         = isset( $new_instance['show_count'] ) ? 1 : 0;
+        $instance['single_only']        = isset( $new_instance['single_only'] ) ? 1 : 0;
         $instance['max_number']         = ! empty( $new_instance['max_number'] ) ? $new_instance['max_number'] : '';
 
 		return $instance;
 	}
 
 	public function widget( $args, $instance ) {
-        $allowWidget = apply_filters('atbdp_allow_locations_widget', true);
+        $allowWidget = apply_filters( 'atbdp_allow_locations_widget', true );
 
-        if( ( ! empty( $instance['single_only'] ) && ! is_singular( ATBDP_POST_TYPE ) ) || ! $allowWidget)
+        if ( ( ! empty( $instance['single_only'] ) && ! is_singular( ATBDP_POST_TYPE ) ) || ! $allowWidget ) {
             return;
+		}
+
 		echo wp_kses_post( $args['before_widget'] );
 
-		$title = !empty($instance['title']) ? esc_html($instance['title']) : esc_html__('Directorist Locations', 'directorist');
-		$widget_title = $args['before_title'] . apply_filters( 'widget_title', $title ) . $args['after_title'];
+		$title = __( 'Directorist Locations', 'directorist' );
+		if ( ! empty( $instance['title'] ) ) {
+			$title = $instance['title'];
+		}
+
+		$widget_title = $args['before_title'] . esc_html( apply_filters( 'widget_title', $title ) ). $args['after_title'];
+
 		echo '<div class="atbd_widget_title">';
 		echo wp_kses_post( $widget_title );
 		echo '</div>';
 
         $query_args = array(
-            'template'       => !empty( $instance['display_as'] ) ? sanitize_text_field( $instance['display_as'] ) : 'list',
-            'parent'         => !empty( $instance['parent'] ) ? (int) $instance['parent'] : 0,
-            'term_id'        => !empty( $instance['parent'] ) ? (int) $instance['parent'] : 0,
-            'hide_empty'     => !empty( $instance['hide_empty'] ) ? 1 : 0,
-            'orderby'        => !empty( $instance['order_by'] ) ? sanitize_text_field( $instance['order_by'] ) : 'id',
-            'order'          => !empty( $instance['order'] ) ? sanitize_text_field( $instance['order'] ) : 'asc',
-            'max_number'     => !empty( $instance['max_number'] ) ? $instance['max_number'] : '',
-            'show_count'     => !empty( $instance['show_count'] ) ? 1 : 0,
-            'single_only'    => !empty( $instance['single_only'] ) ? 1 : 0,
-            'pad_counts'     => true,
+            'template'           => !empty( $instance['display_as'] ) ? sanitize_text_field( $instance['display_as'] ) : 'list',
+            'parent'             => !empty( $instance['parent'] ) ? (int) $instance['parent'] : 0,
+            'term_id'            => !empty( $instance['parent'] ) ? (int) $instance['parent'] : 0,
+            'hide_empty'         => !empty( $instance['hide_empty'] ) ? 1 : 0,
+            'orderby'            => !empty( $instance['order_by'] ) ? sanitize_text_field( $instance['order_by'] ) : 'id',
+            'order'              => !empty( $instance['order'] ) ? sanitize_text_field( $instance['order'] ) : 'asc',
+            'max_number'         => !empty( $instance['max_number'] ) ? $instance['max_number'] : '',
+            'show_count'         => !empty( $instance['show_count'] ) ? 1 : 0,
+            'single_only'        => !empty( $instance['single_only'] ) ? 1 : 0,
+            'pad_counts'         => true,
             'immediate_category' => ! empty( $instance['immediate_category'] ) ? 1 : 0,
-            'active_term_id' => 0,
-            'ancestors'      => array()
+            'active_term_id'     => 0,
+            'ancestors'          => array()
         );
 
-
-        if( $query_args['immediate_category'] ) {
+        if ( $query_args['immediate_category'] ) {
 
             $term_slug = get_query_var( ATBDP_LOCATION );
 
-            if( '' != $term_slug ) {
-				$term = get_term_by( 'slug', $term_slug, ATBDP_LOCATION );
+            if ( '' !== $term_slug ) {
+				$term                         = get_term_by( 'slug', $term_slug, ATBDP_LOCATION );
 				$query_args['active_term_id'] = $term->term_id;
-
-				$query_args['ancestors'] = get_ancestors( $query_args['active_term_id'], 'atbdp_categories' );
-				$query_args['ancestors'][] = $query_args['active_term_id'];
-				$query_args['ancestors'] = array_unique( $query_args['ancestors'] );
+				$query_args['ancestors']      = get_ancestors( $query_args['active_term_id'], 'atbdp_categories' );
+				$query_args['ancestors'][]    = $query_args['active_term_id'];
+				$query_args['ancestors']      = array_unique( $query_args['ancestors'] );
             }
-
         }
 
-        if( 'dropdown' == $query_args['template'] ) {
+        if ( 'dropdown' === $query_args['template'] ) {
             $categories = $this->dropdown_locations( $query_args );
         } else {
             $categories = $this->list_locations( $query_args );
@@ -166,13 +170,10 @@ class All_Locations extends \WP_Widget {
 	}
 
     public function list_locations( $settings ) {
-
-        if( $settings['immediate_category'] ) {
-
-            if( $settings['term_id'] > $settings['parent'] && ! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
-                return;
-            }
-
+        if ( $settings['immediate_category'] &&
+			( $settings['term_id'] > $settings['parent'] ) &&
+			! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
+			return;
         }
 
         $args = array(
@@ -185,12 +186,12 @@ class All_Locations extends \WP_Widget {
             'number'       => !empty($settings['max_number']) ? $settings['max_number'] : ''
         );
 
-        $terms = get_terms( $args );
-        $parent = $args['parent'];
+        $terms       = get_terms( $args );
+        $parent      = $args['parent'];
         $child_class = !empty($parent) ? 'atbdp_child_location' : 'atbdp_parent_location';
-        $html = '';
+        $html        = '';
 
-        if( count( $terms ) > 0 ) {
+        if ( count( $terms ) > 0 ) {
             $i = 1;
             $html .= '<ul class="' .$child_class. '">';
             foreach( $terms as $term ) {

--- a/includes/widgets/all-locations.php
+++ b/includes/widgets/all-locations.php
@@ -75,18 +75,22 @@ class All_Locations extends \WP_Widget {
             'immediate_category' => [
 				'label'   => esc_html__( 'Show all the top-level locations only', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'hide_empty' => [
 				'label'   => esc_html__( 'Hide empty locations', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'show_count' => [
 				'label'   => esc_html__( 'Display listing counts', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'single_only' => [
 				'label'   => esc_html__( 'Display only on single listing', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
         ];
 
@@ -100,10 +104,10 @@ class All_Locations extends \WP_Widget {
 		$instance['display_as']         = ! empty( $new_instance['display_as'] ) ? sanitize_text_field( $new_instance['display_as'] ) : 'list';
         $instance['order_by']           = ! empty( $new_instance['order_by'] ) ? sanitize_text_field( $new_instance['order_by'] ) : 'id';
         $instance['order']              = ! empty( $new_instance['order'] ) ? sanitize_text_field( $new_instance['order'] ) : 'asc';
-        $instance['immediate_category'] = isset( $new_instance['immediate_category'] ) ? 1 : 0;
-        $instance['hide_empty']         = isset( $new_instance['hide_empty'] ) ? 1 : 0;
-        $instance['show_count']         = isset( $new_instance['show_count'] ) ? 1 : 0;
-        $instance['single_only']        = isset( $new_instance['single_only'] ) ? 1 : 0;
+        $instance['immediate_category'] = ! empty( $new_instance['immediate_category'] ) ? 1 : 0;
+        $instance['hide_empty']         = ! empty( $new_instance['hide_empty'] ) ? 1 : 0;
+        $instance['show_count']         = ! empty( $new_instance['show_count'] ) ? 1 : 0;
+        $instance['single_only']        = ! empty( $new_instance['single_only'] ) ? 1 : 0;
         $instance['max_number']         = ! empty( $new_instance['max_number'] ) ? $new_instance['max_number'] : '';
 
 		return $instance;
@@ -186,104 +190,81 @@ class All_Locations extends \WP_Widget {
             'number'       => !empty($settings['max_number']) ? $settings['max_number'] : ''
         );
 
-        $terms       = get_terms( $args );
+        $terms = get_terms( $args );
+
+		if ( is_wp_error( $terms ) ) {
+			return;
+		}
+
         $parent      = $args['parent'];
-        $child_class = !empty($parent) ? 'atbdp_child_location' : 'atbdp_parent_location';
+        $child_class = ! empty( $parent ) ? 'atbdp_child_location' : 'atbdp_parent_location';
         $html        = '';
+		$html .= '<ul class="' .$child_class. '">';
 
-        if ( count( $terms ) > 0 ) {
-            $i = 1;
-            $html .= '<ul class="' .$child_class. '">';
-            foreach( $terms as $term ) {
-                $child_category = get_term_children($term->term_id,ATBDP_LOCATION);
-                $plus_icon = (!empty($child_category) && empty($parent) ) ? directorist_icon( 'las la-plus', false ) : '';
-                $settings['term_id'] = $term->term_id;
+		foreach ( $terms as $term ) {
+			$child_category = get_term_children($term->term_id,ATBDP_LOCATION);
+			$plus_icon = (!empty($child_category) && empty($parent) ) ? directorist_icon( 'las la-plus', false ) : '';
+			$settings['term_id'] = $term->term_id;
 
-                $count = 0;
-                if( ! empty( $settings['hide_empty'] ) || ! empty( $settings['show_count'] ) ) {
-                    $count = atbdp_listings_count_by_location( $term->term_id );
+			$html .= '<li>';
+			$html .= '<a href="' . \ATBDP_Permalink::atbdp_get_location_page( $term ) . '">';
+			$html .= $term->name;
 
-                    if( ! empty( $settings['hide_empty'] ) && 0 == $count ) continue;
-                }
+			if ( ! empty( $settings['show_count'] ) ) {
+				$html .= ' (' . $term->count . ')';
+			}
 
-                $html .= '<li>';
-                $html .= '<a href="' . \ATBDP_Permalink::atbdp_get_location_page( $term ) . '">';
-                $html .= $term->name;
-                if( ! empty( $settings['show_count'] ) ) {
-                    $expired_listings = atbdp_get_expired_listings(ATBDP_LOCATION, $term->term_id);
-                    $number_of_expired = $expired_listings->post_count;
-                    $number_of_expired = !empty($number_of_expired)?$number_of_expired:'0';
-                    $totat = ($count)?($count-$number_of_expired):$count;
-                    $html .= ' (' . $totat . ')';
-                }
-                $html .= '</a>'. $plus_icon . '';
-                $html .= $this->list_locations( $settings );
-                $html .= '</li>';
-                if(!empty($args['number'])) {
-                    if( $i++ == $args['number'] ) break;
-                }
-            }
-            $html .= '</ul>';
+			$html .= '</a>'. $plus_icon . '';
+			$html .= $this->list_locations( $settings );
+			$html .= '</li>';
+		}
 
-        }
+		$html .= '</ul>';
 
         return $html;
 
     }
 
     public function dropdown_locations( $settings, $prefix = '' ) {
-
-        if( $settings['immediate_category'] ) {
-
-            if( $settings['term_id'] > $settings['parent'] && ! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
-                return;
-            }
-
+        if ( $settings['immediate_category'] &&
+			( $settings['term_id'] > $settings['parent'] ) &&
+			! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
+			return;
         }
 
         $term_slug = get_query_var( ATBDP_LOCATION );
 
         $args = array(
             'taxonomy'     => ATBDP_LOCATION,
-            'orderby'      => $settings['orderby'],
             'order'        => $settings['order'],
+            'orderby'      => $settings['orderby'],
             'hide_empty'   => $settings['hide_empty'],
-            'parent'       => !empty($settings['term_id']) ? $settings['term_id'] : '',
             'hierarchical' => ! empty( $settings['hide_empty'] ) ? true : false,
-            'number'       => !empty($settings['max_number']) ? $settings['max_number'] : ''
+            'parent'       => ! empty( $settings['term_id'] ) ? $settings['term_id'] : '',
+            'number'       => ! empty( $settings['max_number'] ) ? $settings['max_number'] : ''
         );
 
         $terms = get_terms( $args );
 
+		if ( is_wp_error( $terms ) ) {
+			return;
+		}
+
         $html = '';
 
-        if( count( $terms ) > 0 ) {
-            $i = 1;
-            foreach( $terms as $term ) {
-                $settings['term_id'] = $term->term_id;
+		foreach ( $terms as $term ) {
+			$settings['term_id'] = $term->term_id;
 
-                $count = 0;
-                if( ! empty( $settings['hide_empty'] ) || ! empty( $settings['show_count'] ) ) {
-                    $count = atbdp_listings_count_by_category( $term->term_id );
+			$html .= sprintf( '<option value="%s" %s>', $term->term_id, selected( $term->term_id, $term_slug, false ) );
+			$html .= $prefix . $term->name;
 
-                    if( ! empty( $settings['hide_empty'] ) && 0 == $count ) continue;
-                }
-
-                $html .= sprintf( '<option value="%s" %s>', $term->term_id, selected( $term->term_id, $term_slug, false ) );
-                $html .= $prefix . $term->name;
-                if( ! empty( $settings['show_count'] ) ) {
-                    $html .= ' (' . $count . ')';
-                }
-                //$html .= $this->dropdown_locations( $settings, $prefix . '&nbsp;&nbsp;&nbsp;' );
-                $html .= '</option>';
-                if(!empty($args['number'])) {
-                    if( $i++ == $args['number'] ) break;
-                }
-            }
-
-        }
+			if ( ! empty( $settings['show_count'] ) ) {
+				$html .= ' (' . $term->count . ')';
+			}
+			//$html .= $this->dropdown_locations( $settings, $prefix . '&nbsp;&nbsp;&nbsp;' );
+			$html .= '</option>';
+		}
 
         return $html;
-
     }
 }

--- a/includes/widgets/all-tags.php
+++ b/includes/widgets/all-tags.php
@@ -74,14 +74,17 @@ class All_Tags extends \WP_Widget {
             'hide_empty' => [
 				'label'   => esc_html__( 'Hide empty tags', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'show_count' => [
 				'label'   => esc_html__( 'Display listing counts', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
             'display_single_tag' => [
 				'label'   => esc_html__( 'Display single listing tags', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
         ];
 

--- a/includes/widgets/all-tags.php
+++ b/includes/widgets/all-tags.php
@@ -98,9 +98,9 @@ class All_Tags extends \WP_Widget {
 		$instance['display_as']         = ! empty( $new_instance['display_as'] ) ? sanitize_text_field( $new_instance['display_as'] ) : 'list';
         $instance['order_by']           = ! empty( $new_instance['order_by'] ) ? sanitize_text_field( $new_instance['order_by'] ) : 'id';
         $instance['order']              = ! empty( $new_instance['order'] ) ? sanitize_text_field( $new_instance['order'] ) : 'asc';
-        $instance['hide_empty']         = isset( $new_instance['hide_empty'] ) ? 1 : 0;
-        $instance['show_count']         = isset( $new_instance['show_count'] ) ? 1 : 0;
-        $instance['display_single_tag'] = isset( $new_instance['display_single_tag'] ) ? 1 : 0;
+        $instance['hide_empty']         = ! empty( $new_instance['hide_empty'] ) ? 1 : 0;
+        $instance['show_count']         = ! empty( $new_instance['show_count'] ) ? 1 : 0;
+        $instance['display_single_tag'] = ! empty( $new_instance['display_single_tag'] ) ? 1 : 0;
         $instance['max_number']         = ! empty( $new_instance['max_number'] ) ? $new_instance['max_number'] : '';
 
 		return $instance;
@@ -164,13 +164,13 @@ class All_Tags extends \WP_Widget {
 	}
 
     public function directorist_tags_list( $settings ) {
-
-        if( $settings['display_single_tag'] ) {
+        if ( $settings['display_single_tag'] ) {
             $terms = get_the_terms(get_the_ID(), ATBDP_TAGS);
             $html = '';
-            if (!empty($terms)) {
+
+            if ( ! empty( $terms ) ) {
                 $html .= '<ul>';
-                foreach ($terms as $term) {
+                foreach ( $terms as $term ) {
                     $html .= '<li>';
                     $html .= '<a href="' . \ATBDP_Permalink::atbdp_get_tag_page($term) . '">';
                     $html .= $term->name;
@@ -180,65 +180,56 @@ class All_Tags extends \WP_Widget {
                 $html .= '</ul>';
             }
         } else {
-
-
-            if ($settings['immediate_category']) {
-
-                if ($settings['term_id'] > $settings['parent'] && !in_array($settings['term_id'], $settings['ancestors'])) {
-                    return;
-                }
-
+            if ( $settings['immediate_category'] &&
+				( $settings['term_id'] > $settings['parent'] ) &&
+				! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
+				return;
             }
 
             $args = array(
-                'taxonomy' => ATBDP_TAGS,
-                'orderby' => $settings['orderby'],
-                'order' => $settings['order'],
-                'hide_empty' => $settings['hide_empty'],
-                'parent' => !empty($settings['term_id']) ? $settings['term_id'] : '',
+                'taxonomy'     => ATBDP_TAGS,
+                'orderby'      => $settings['orderby'],
+                'order'        => $settings['order'],
+                'hide_empty'   => $settings['hide_empty'],
+                'parent'       => !empty($settings['term_id']) ? $settings['term_id'] : '',
                 'hierarchical' => !empty($settings['hide_empty']) ? true : false,
-                'number' => !empty($settings['max_number']) ? $settings['max_number'] : ''
+                'number'       => !empty($settings['max_number']) ? $settings['max_number'] : ''
             );
+
             $terms = get_terms( $args );
 
+			if ( is_wp_error( $terms ) ) {
+				return;
+			}
+
             $html = '';
+			$html .= '<ul>';
 
-            if (count($terms) > 0) {
+			foreach ( $terms as $term ) {
+				$settings['term_id'] = $term->term_id;
 
-                $html .= '<ul>';
+				$html .= '<li>';
+				$html .= '<a href="' . \ATBDP_Permalink::atbdp_get_tag_page( $term ) . '">';
+				$html .= $term->name;
 
-                foreach ($terms as $term) {
-                    $settings['term_id'] = $term->term_id;
+				if ( ! empty( $settings['show_count'] ) ) {
+					$html .= ' (' . $term->count . ')';
+				}
 
-                    $count = 0;
-                    if (!empty($settings['hide_empty']) || !empty($settings['show_count'])) {
-                        $count = atbdp_listings_count_by_tag($term->term_id);
+				$html .= '</a>';
+				// $html .= $this->directorist_tags_list($settings);
+				$html .= '</li>';
+			}
 
-                        if (!empty($settings['hide_empty']) && 0 == $count) continue;
-                    }
-
-                    $html .= '<li>';
-                    $html .= '<a href="' . \ATBDP_Permalink::atbdp_get_tag_page($term) . '">';
-                    $html .= $term->name;
-                    if (!empty($settings['show_count'])) {
-                        $html .= ' (' . $count . ')';
-                    }
-                    $html .= '</a>';
-                   // $html .= $this->directorist_tags_list($settings);
-                    $html .= '</li>';
-                }
-
-                $html .= '</ul>';
-
-            }
+			$html .= '</ul>';
         }
+
         return $html;
-
-
-
     }
 
     public function dropdown_tags( $settings, $prefix = '' ) {
+		print_r( $settings );
+
         $term_slug = get_query_var(ATBDP_TAGS);
         if( $settings['display_single_tag'] ) {
             $terms = get_the_terms(get_the_ID(), ATBDP_TAGS);
@@ -254,52 +245,45 @@ class All_Tags extends \WP_Widget {
             }
         } else {
 
-            if ($settings['immediate_category']) {
-
-                if ($settings['term_id'] > $settings['parent'] && !in_array($settings['term_id'], $settings['ancestors'])) {
-                    return;
-                }
-
+            if ( $settings['immediate_category'] &&
+				( $settings['term_id'] > $settings['parent'] ) &&
+				! in_array( $settings['term_id'], $settings['ancestors'] ) ) {
+				return;
             }
 
             $args = array(
-                    'taxonomy' => ATBDP_TAGS,
-                    'orderby' => $settings['orderby'],
-                    'order' => $settings['order'],
-                    'hide_empty' => $settings['hide_empty'],
-                    'parent' => !empty($settings['term_id']) ? $settings['term_id'] : '',
-                    'hierarchical' => !empty($settings['hide_empty']) ? true : false,
-                    'number' => !empty($settings['max_number']) ? $settings['max_number'] : ''
-                );
+				'taxonomy'     => ATBDP_TAGS,
+				'orderby'      => $settings['orderby'],
+				'order'        => $settings['order'],
+				'hide_empty'   => $settings['hide_empty'],
+				'parent'       => !empty($settings['term_id']) ? $settings['term_id'] : '',
+				'hierarchical' => !empty($settings['hide_empty']) ? true : false,
+				'number'       => !empty($settings['max_number']) ? $settings['max_number'] : ''
+			);
 
             $terms = get_terms( $args );
 
+			if ( is_wp_error( $terms ) ) {
+				return;
+			}
+
             $html = '';
 
-            if (count($terms) > 0) {
+			foreach ( $terms as $term ) {
+				$settings['term_id'] = $term->term_id;
 
-                foreach ($terms as $term) {
-                    $settings['term_id'] = $term->term_id;
+				$html .= sprintf('<option value="%s" %s>', $term->term_taxonomy_id, selected($term->slug, $term_slug, false));
+				$html .= $prefix . $term->name;
 
-                    $count = 0;
-                    if (!empty($settings['hide_empty']) || !empty($settings['show_count'])) {
-                        $count = atbdp_listings_count_by_tag($term->term_id);
+				if ( ! empty( $settings['show_count'] ) ) {
+					$html .= ' (' . $term->count . ')';
+				}
 
-                        if (!empty($settings['hide_empty']) && 0 == $count) continue;
-                    }
-
-                    $html .= sprintf('<option value="%s" %s>', $term->term_taxonomy_id, selected($term->slug, $term_slug, false));
-                    $html .= $prefix . $term->name;
-                    if (!empty($settings['show_count'])) {
-                        $html .= ' (' . $count . ')';
-                    }
-                    //$html .= $this->dropdown_tags($settings, $prefix . '&nbsp;&nbsp;&nbsp;');
-                    $html .= '</option>';
-                }
-
-            }
+				//$html .= $this->dropdown_tags($settings, $prefix . '&nbsp;&nbsp;&nbsp;');
+				$html .= '</option>';
+			}
         }
-        return $html;
 
+        return $html;
     }
 }

--- a/includes/widgets/all-tags.php
+++ b/includes/widgets/all-tags.php
@@ -228,8 +228,6 @@ class All_Tags extends \WP_Widget {
     }
 
     public function dropdown_tags( $settings, $prefix = '' ) {
-		print_r( $settings );
-
         $term_slug = get_query_var(ATBDP_TAGS);
         if( $settings['display_single_tag'] ) {
             $terms = get_the_terms(get_the_ID(), ATBDP_TAGS);

--- a/includes/widgets/featured-listing.php
+++ b/includes/widgets/featured-listing.php
@@ -43,6 +43,7 @@ class Featured_Listing extends \WP_Widget {
             'single_only' => [
 				'label'   => esc_html__( 'Display only on single listing', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
         ];
 

--- a/includes/widgets/lib-widget-fields.php
+++ b/includes/widgets/lib-widget-fields.php
@@ -83,7 +83,7 @@ class Widget_Fields {
 
 	protected static function checkbox( $id, $name, $value, $label, $options, $field ) {
 		?>
-		<input type="checkbox" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php checked( $value ); ?> />
+		<input type="checkbox" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( $field['value'] ); ?>" <?php checked( $value, $field['value'] ); ?> />
 		<label for="<?php echo esc_attr( $id ); ?>" class="directorist-widget-label-inline"><?php echo esc_html( $label ); ?></label>
 		<?php
 	}

--- a/includes/widgets/login-form.php
+++ b/includes/widgets/login-form.php
@@ -38,6 +38,7 @@ class Login_Form extends \WP_Widget {
 			'single_only' => [
 				'label'   => esc_html__( 'Display only on single listing', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
         ];
 

--- a/includes/widgets/login-form.php
+++ b/includes/widgets/login-form.php
@@ -49,7 +49,7 @@ class Login_Form extends \WP_Widget {
 		$instance = [];
 
 		$instance['title']            = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
-		$instance['single_only']      = isset( $new_instance['single_only'] ) ? 1 : 0;
+		$instance['single_only']      = ! empty( $new_instance['single_only'] ) ? 1 : 0;
 
 		return $instance;
 	}

--- a/includes/widgets/popular-listings.php
+++ b/includes/widgets/popular-listings.php
@@ -43,6 +43,7 @@ class Popular_Listings extends \WP_Widget {
 			'single_only' => [
 				'label'   => esc_html__( 'Display only on single listing', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
         ];
 

--- a/includes/widgets/popular-listings.php
+++ b/includes/widgets/popular-listings.php
@@ -55,7 +55,7 @@ class Popular_Listings extends \WP_Widget {
 
 		$instance['title']            = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
 		$instance['pop_listing_num']  = ! empty( $new_instance['pop_listing_num'] ) ? sanitize_text_field( $new_instance['pop_listing_num'] ) : '';
-		$instance['single_only']      = isset( $new_instance['single_only'] ) ? 1 : 0;
+		$instance['single_only']      = ! empty( $new_instance['single_only'] ) ? 1 : 0;
 
 		return $instance;
 	}

--- a/includes/widgets/submit-listing.php
+++ b/includes/widgets/submit-listing.php
@@ -38,6 +38,7 @@ class Submit_Listing extends \WP_Widget {
 			'single_only' => [
 				'label'   => esc_html__( 'Display only on single listing', 'directorist' ),
 				'type'    => 'checkbox',
+				'value'   => 1,
 			],
         ];
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix
- Improvement

## Description
Checkbox input fields in widgets have issues with the value, so refactored the checkbox value and refactored terms queries and listings count.

How to reproduce the issue or how to test the changes

1. Use the locations widget
2. Try selecting the checkboxes
3. Save the widget, and you'll see that the widget doesn't update the checkboxes!

## Any linked issues
Fixes # Customer support

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
