### PR TITLE
Update: set default delete_expired_listing value to false

### DIFF
--- a/assets/sample-data/directory/directory-settings.json
+++ b/assets/sample-data/directory/directory-settings.json
@@ -80,7 +80,7 @@
     "can_renew_listing": true,
     "email_to_expire_day": "7",
     "email_renewal_day": "7",
-    "delete_expired_listing": true,
+    "delete_expired_listing": false,
     "delete_expired_listings_after": 15,
     "deletion_mode": "trash",
     "paginate_author_listings": true,

--- a/includes/classes/class-cron.php
+++ b/includes/classes/class-cron.php
@@ -226,7 +226,7 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
 			$can_renew         = get_directorist_option( 'can_renew_listing' );
 			$email_renewal_day = get_directorist_option( 'email_renewal_day' );
 			$delete_in_days    = get_directorist_option( 'delete_expired_listings_after' );
-			$del_exp_l         = get_directorist_option( 'delete_expired_listing', 1 );
+			$del_exp_l         = get_directorist_option( 'delete_expired_listing' );
 			// add renewal reminder days to deletion thresholds
 			$delete_threshold = $can_renew ? (int) $email_renewal_day + (int) $delete_in_days : $delete_in_days;
 
@@ -411,7 +411,7 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
 		 */
 		private function delete_expired_listings() {
 
-			$del_exp_l = get_directorist_option( 'delete_expired_listing', 1 );
+			$del_exp_l = get_directorist_option( 'delete_expired_listing' );
 			if ( ! $del_exp_l ) {
 				return; // vail if admin does not want to delete expired listing
 			}

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -1477,7 +1477,7 @@ Please remember that your order may be canceled if you do not make your payment 
                 'delete_expired_listing' => [
                     'label' => __('Delete/Trash Expired Listings', 'directorist'),
                     'type'  => 'toggle',
-                    'value' => true,
+                    'value' => false,
                 ],
                 'delete_expired_listings_after' => [
                     'label' => __('Delete/Trash Expired Listings After (days) of Expiration', 'directorist'),


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

Set default **delete_expired_listing** value to false
https://prnt.sc/zAGJPY1ZTw7M

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
