### PR TITLE
fix: remove the empty space from the url parameter

### DIFF
--- a/includes/classes/class-permalink.php
+++ b/includes/classes/class-permalink.php
@@ -379,7 +379,7 @@ class ATBDP_Permalink {
             if ( '' != get_option( 'permalink_structure' ) ) {
                 $link = user_trailingslashit( trailingslashit( $link )  . 'edit/' . $listing_id );
             } else {
-                $link = add_query_arg( array( 'atbdp_action' => 'edit', 'atbdp_listing_id ' => $listing_id ), $link );
+                $link = add_query_arg( array( 'atbdp_action' => 'edit', 'atbdp_listing_id' => $listing_id ), $link );
             }
         }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

Remove the empty space " " from url parameter. It was causing an error in the edit listing link as it was dropping an empty space in the URL. Please try a different permalink structure.

![image](https://github.com/sovware/directorist/assets/33813593/f999100c-5114-4e3a-9ff4-1dc57ca92a72)


## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
