### PR TITLE
Improved mono directory listing queries

### DIFF
--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -465,11 +465,13 @@ class Directorist_Listings {
 			$current_order = atbdp_get_listings_current_order( $this->orderby . '-' . $this->order );
 		}
 
-		$meta_queries['directory_type'] = array(
-			'key'     => '_directory_type',
-			'value'   => $this->get_current_listing_type(),
-			'compare' => '=',
-		);
+		if ( directorist_is_multi_directory_enabled() ) {
+			$meta_queries['directory_type'] = array(
+				'key'     => '_directory_type',
+				'value'   => $this->get_current_listing_type(),
+				'compare' => '=',
+			);
+		}
 
 		$meta_queries['expired'] = array(
 			'key'     => '_listing_status',
@@ -1205,17 +1207,17 @@ class Directorist_Listings {
 			$directory = get_post_meta( get_the_ID(), '_directory_type', true );
 		} else if ( ! empty( $_REQUEST['directory_type'] ) ) {
 			$directory = sanitize_text_field( wp_unslash( $_REQUEST['directory_type'] ) );
-	
+
 			if ( ! is_numeric( $directory ) ) {
 				$directory_term = get_term_by( 'slug', $directory, ATBDP_DIRECTORY_TYPE );
 				$directory      = $directory_term ? $directory_term->term_id : 0;
 			}
 		}
-	
+
 		if ( ! empty( $directory ) && directorist_is_directory( $directory ) ) {
 			return (int) $directory;
 		}
-		
+
 		return directorist_get_default_directory();
 	}
 

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -1183,11 +1183,14 @@ class Directorist_Single_Listing {
 				'value'   => 'expired',
 				'compare' => '!=',
 			);
-		$meta_queries['directory_type'] = array(
+
+		if ( directorist_is_multi_directory_enabled() ) {
+			$meta_queries['directory_type'] = array(
 				'key'     => '_directory_type',
 				'value'   => $this->type,
 				'compare' => '=',
 			);
+		}
 
 		$meta_queries = apply_filters('atbdp_related_listings_meta_queries', $meta_queries);
 		$count_meta_queries = count($meta_queries);

--- a/includes/rest-api/Version1/class-listings-controller.php
+++ b/includes/rest-api/Version1/class-listings-controller.php
@@ -656,7 +656,7 @@ class Listings_Controller extends Posts_Controller {
 	 * @param WP_Post   $listing WP_Post instance.
 	 * @param WP_REST_Request $request Request object.
 	 * @param string    $context Request context. Options: 'view' and 'edit'.
-	 * 
+	 *
 	 * @return array
 	 */
 	protected function get_listing_data( $listing, $request, $context = 'view' ) {
@@ -871,11 +871,14 @@ class Listings_Controller extends Posts_Controller {
 			'value'   => 'expired',
 			'compare' => '!=',
 		);
-		$meta_queries['directory_type'] = array(
-			'key'     => '_directory_type',
-			'value'   => $directory_type,
-			'compare' => '=',
-		);
+
+		if ( directorist_is_multi_directory_enabled() ) {
+			$meta_queries['directory_type'] = array(
+				'key'     => '_directory_type',
+				'value'   => $directory_type,
+				'compare' => '=',
+			);
+		}
 
 		$meta_queries = apply_filters('atbdp_related_listings_meta_queries', $meta_queries);
 		$count_meta_queries = count($meta_queries);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Improvement

## Description
Usually, users build a single site. So, when multi-directory is disabled there's no need to include the directory query along with the listings query. And that's why we made the directory query conditional to improve the query performance of a single directory site.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
