### PR TITLE
Removed function argument data type hint due to backward incompatibility

### DIFF
--- a/includes/directorist-directory-functions.php
+++ b/includes/directorist-directory-functions.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-function directorist_get_directory_meta( int $directory_id, string $meta_key ) {
+function directorist_get_directory_meta( $directory_id, string $meta_key ) {
 	if ( ! term_exists( $directory_id, ATBDP_DIRECTORY_TYPE ) ) {
 		return false;
 	}
@@ -24,7 +24,7 @@ function directorist_get_directory_meta( int $directory_id, string $meta_key ) {
     return get_term_meta( $directory_id, $meta_key, true );
 }
 
-function directorist_get_listing_form_fields( int $directory_id ) {
+function directorist_get_listing_form_fields( $directory_id ) {
 	$form_data = directorist_get_directory_meta( $directory_id, 'submission_form_fields' );
 	$_fields   = directorist_get_var( $form_data['fields'], array() );
 	$_groups   = directorist_get_var( $form_data['groups'], array() );
@@ -43,7 +43,7 @@ function directorist_get_listing_form_fields( int $directory_id ) {
 	return $fields;
 }
 
-function directorist_get_listing_form_groups( int $directory_id ) {
+function directorist_get_listing_form_groups( $directory_id ) {
 	$form_data = directorist_get_directory_meta( $directory_id, 'submission_form_fields' );
 	$_groups   = directorist_get_var( $form_data['groups'], array() );
 	$groups    = array();
@@ -68,36 +68,36 @@ function directorist_get_listing_form_field( $directory_id, $field_key = '' ) {
 	return empty( $form_fields[ $field_key ] ) ? array() : $form_fields[ $field_key ];
 }
 
-function directorist_get_listing_form_category_field( int $directory_id ) {
+function directorist_get_listing_form_category_field( $directory_id ) {
 	return directorist_get_listing_form_field( $directory_id, 'category' );
 }
 
-function directorist_listing_form_has_category_field( int $directory_id ) {
+function directorist_listing_form_has_category_field( $directory_id ) {
 	$category_field = directorist_get_listing_form_category_field( $directory_id );
 	return ! empty( $category_field );
 }
 
-function directorist_is_terms_and_condition_enabled( int $directory_id ) {
+function directorist_is_terms_and_condition_enabled( $directory_id ) {
 	return (bool) directorist_get_directory_meta( $directory_id, 'listing_terms_condition' );
 }
 
-function directorist_is_terms_and_condition_required( int $directory_id ) {
+function directorist_is_terms_and_condition_required( $directory_id ) {
 	return (bool) directorist_get_directory_meta( $directory_id, 'require_terms_conditions' );
 }
 
-function directorist_should_check_terms_and_condition( int $directory_id ) {
+function directorist_should_check_terms_and_condition( $directory_id ) {
 	return ( directorist_is_terms_and_condition_enabled( $directory_id ) && directorist_is_terms_and_condition_required( $directory_id ) );
 }
 
-function directorist_is_privacy_policy_enabled( int $directory_id ) {
+function directorist_is_privacy_policy_enabled( $directory_id ) {
 	return (bool) directorist_get_directory_meta( $directory_id, 'listing_privacy' );
 }
 
-function directorist_is_privacy_policy_required( int $directory_id ) {
+function directorist_is_privacy_policy_required( $directory_id ) {
 	return (bool) directorist_get_directory_meta( $directory_id, 'require_privacy' );
 }
 
-function directorist_should_check_privacy_policy( int $directory_id ) {
+function directorist_should_check_privacy_policy( $directory_id ) {
 	return ( directorist_is_privacy_policy_enabled( $directory_id ) && directorist_is_privacy_policy_required( $directory_id ) );
 }
 
@@ -108,9 +108,9 @@ function directorist_should_check_privacy_policy( int $directory_id ) {
  *
  * @return string Default create status.
  */
-function directorist_get_listing_create_status( int $directory_id ) {
+function directorist_get_listing_create_status( $directory_id ) {
 	$status = directorist_get_directory_meta( $directory_id, 'new_listing_status' );
-	
+
 	return apply_filters( 'directorist_listing_create_status', $status, $directory_id );
 }
 
@@ -121,13 +121,13 @@ function directorist_get_listing_create_status( int $directory_id ) {
  *
  * @return string Default edit status.
  */
-function directorist_get_listing_edit_status( int $directory_id ) {
+function directorist_get_listing_edit_status( $directory_id ) {
 	$status = directorist_get_directory_meta( $directory_id, 'edit_listing_status' );
 
 	return apply_filters( 'directorist_listing_edit_status', $status, $directory_id );
 }
 
-function directorist_get_default_expiration( int $directory_id ) {
+function directorist_get_default_expiration( $directory_id ) {
 	return directorist_get_directory_meta( $directory_id, 'default_expiration' );
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix


## Description
Internal

## Any linked issues
Internal test issue

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
