### PR TITLE
Fix: date time format on archive and single listing page

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4266,23 +4266,37 @@ function directorist_delete_temporary_upload_dirs() {
 }
 
 /**
- * Formats a given date/time value according to WordPress settings or provided format.
+ * Formats a given date value according to WordPress settings or provided format.
  *
- * @param string $value The date/time value to format.
- * @param string $type The type of format, either 'date' or 'time'. Default is 'date'.
+ * @param string $date The date value to format.
  * @param string $format Optional. The format to use. If empty, uses the WordPress settings.
- * @return string The formatted date/time string, or an empty string if the input value is empty.
+ * @return string The formatted date string, or an empty string if the input value is empty.
  */
-function directorist_date_time_format( $value = '', $type = 'date', $format = '' ) {
-    // Return an empty string if the input value is empty
-    if ( empty( $value ) ) {
+function directorist_format_date( $date = '', $format = '' ) {
+    $date = strtotime( $date );
+    if ( ! $date ) {
         return '';
     }
 
-    // Determine the format to use based on the type and input format
-    $default_format = ( 'time' === $type ) ? get_option( 'time_format' ) : get_option( 'date_format' );
-    $format = ! empty( $format ) ? $format : $default_format;
+    $format = apply_filters( 'directorist_date_format', ( $format ? $format : get_option( 'date_format' ) ) );
 
-    // Format and return the date/time value using the determined format
-    return date( apply_filters( 'directorist_date_time_format', $format, $type, 'single' ), strtotime( esc_html( $value ) ) );
+    return date( $format, $date );
+}
+
+/**
+ * Formats a given time value according to WordPress settings or provided format.
+ *
+ * @param string $time The time value to format.
+ * @param string $format Optional. The format to use. If empty, uses the WordPress settings.
+ * @return string The formatted time string, or an empty string if the input value is empty.
+ */
+function directorist_format_time( $time = '', $format = '' ) {
+    $time = strtotime( $time );
+    if ( ! $time ) {
+        return '';
+    }
+
+    $format = apply_filters( 'directorist_time_format', ( $format ? $format : get_option( 'time_format' ) ) );
+
+    return date( $format, $time );
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4264,3 +4264,25 @@ function directorist_delete_temporary_upload_dirs() {
 		}
 	}
 }
+
+/**
+ * Formats a given date/time value according to WordPress settings or provided format.
+ *
+ * @param string $value The date/time value to format.
+ * @param string $type The type of format, either 'date' or 'time'. Default is 'date'.
+ * @param string $format Optional. The format to use. If empty, uses the WordPress settings.
+ * @return string The formatted date/time string, or an empty string if the input value is empty.
+ */
+function directorist_date_time_format( $value = '', $type = 'date', $format = '' ) {
+    // Return an empty string if the input value is empty
+    if ( empty( $value ) ) {
+        return '';
+    }
+
+    // Determine the format to use based on the type and input format
+    $default_format = ( 'time' === $type ) ? get_option( 'time_format' ) : get_option( 'date_format' );
+    $format = ! empty( $format ) ? $format : $default_format;
+
+    // Format and return the date/time value using the determined format
+    return date( apply_filters( 'directorist_date_time_format', $format, $type, 'single' ), strtotime( esc_html( $value ) ) );
+}

--- a/templates/archive/custom-fields/date.php
+++ b/templates/archive/custom-fields/date.php
@@ -8,4 +8,4 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
 
-<div class="directorist-listing-card-date"><?php directorist_icon( $icon );?><?php $listings->print_label( $label ); ?><?php echo esc_html( directorist_date_time_format( $value, 'date' ) ); ?></div>
+<div class="directorist-listing-card-date"><?php directorist_icon( $icon );?><?php $listings->print_label( $label ); ?><?php echo esc_html( directorist_format_date( $value ) ); ?></div>

--- a/templates/archive/custom-fields/date.php
+++ b/templates/archive/custom-fields/date.php
@@ -2,10 +2,10 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 6.7
+ * @version 7.10.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
 
-<div class="directorist-listing-card-date"><?php directorist_icon( $icon );?><?php $listings->print_label( $label ); ?><?php echo esc_html( $value ); ?></div>
+<div class="directorist-listing-card-date"><?php directorist_icon( $icon );?><?php $listings->print_label( $label ); ?><?php echo esc_html( directorist_date_time_format( $value, 'date' ) ); ?></div>

--- a/templates/archive/custom-fields/time.php
+++ b/templates/archive/custom-fields/time.php
@@ -8,4 +8,4 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
 
-<div class="directorist-listing-card-time"><?php directorist_icon( $icon ); ?><?php $listings->print_label( $label ); ?><?php echo esc_html( directorist_date_time_format( $value, 'time' ) ); ?></div>
+<div class="directorist-listing-card-time"><?php directorist_icon( $icon ); ?><?php $listings->print_label( $label ); ?><?php echo esc_html( directorist_format_time( $value ) ); ?></div>

--- a/templates/archive/custom-fields/time.php
+++ b/templates/archive/custom-fields/time.php
@@ -2,10 +2,10 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 6.7
+ * @version 7.10.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
 
-<div class="directorist-listing-card-time"><?php directorist_icon( $icon ); ?><?php $listings->print_label( $label ); ?><?php echo esc_html( $value ); ?></div>
+<div class="directorist-listing-card-time"><?php directorist_icon( $icon ); ?><?php $listings->print_label( $label ); ?><?php echo esc_html( directorist_date_time_format( $value, 'time' ) ); ?></div>

--- a/templates/single/custom-fields/date.php
+++ b/templates/single/custom-fields/date.php
@@ -15,6 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 		<span class="directorist-single-info__label--text"><?php echo esc_html( $data['label'] ); ?></span>
 	</div>
 
-	<div class="directorist-single-info__value"><?php echo esc_html( directorist_date_time_format( $value, 'date' ) ); ?></div>
+	<div class="directorist-single-info__value"><?php echo esc_html( directorist_format_date( $value ) ); ?></div>
 
 </div>

--- a/templates/single/custom-fields/date.php
+++ b/templates/single/custom-fields/date.php
@@ -2,12 +2,10 @@
 /**
  * @author  wpWax
  * @since   6.7
- * @version 7.3.1
+ * @version 7.10.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
-
-$date_format = get_option( 'date_format' );
 ?>
 
 <div class="directorist-single-info directorist-single-info-date">
@@ -17,6 +15,6 @@ $date_format = get_option( 'date_format' );
 		<span class="directorist-single-info__label--text"><?php echo esc_html( $data['label'] ); ?></span>
 	</div>
 
-	<div class="directorist-single-info__value"><?php echo esc_html( date( $date_format, strtotime( esc_html( $value ) ) ) ); ?></div>
+	<div class="directorist-single-info__value"><?php echo esc_html( directorist_date_time_format( $value, 'date' ) ); ?></div>
 
 </div>

--- a/templates/single/custom-fields/time.php
+++ b/templates/single/custom-fields/time.php
@@ -15,6 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 		<span class="directorist-single-info__label--text"><?php echo esc_html( $data['label'] ); ?></span>
 	</div>
 
-	<div class="directorist-single-info__value"><?php echo esc_html( directorist_date_time_format( $value, 'time' ) ); ?></div>
+	<div class="directorist-single-info__value"><?php echo esc_html( directorist_format_time( $value ) ); ?></div>
 
 </div>

--- a/templates/single/custom-fields/time.php
+++ b/templates/single/custom-fields/time.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.7
- * @version 7.3.1
+ * @version 7.10.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -15,6 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 		<span class="directorist-single-info__label--text"><?php echo esc_html( $data['label'] ); ?></span>
 	</div>
 
-	<div class="directorist-single-info__value"><?php echo esc_html( date( 'h:i A', strtotime( esc_html( $value ) ) ) ); ?></div>
+	<div class="directorist-single-info__value"><?php echo esc_html( directorist_date_time_format( $value, 'time' ) ); ?></div>
 
 </div>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Date time format was not following the Wordpress default date time format.
We received a good number of requests from customers.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
