### PR TITLE
Fixed never expire meta not deleting issue

### DIFF
--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -303,7 +303,7 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 
 				$listing_create_status = directorist_get_listing_create_status( $directory_id );
 				$listing_edit_status   = directorist_get_listing_edit_status( $directory_id );
-				$default_expiration    = get_term_meta( $directory_id, 'default_expiration', true );
+				$default_expiration    = directorist_get_default_expiration( $directory_id );
 				$preview_enable        = atbdp_is_truthy( get_term_meta( $directory_id, 'preview_mode', true ) );
 
 				/**
@@ -369,7 +369,7 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 
 					// Every post with the published status should contain all the post meta keys so that we can include them in query.
 					if ( 'publish' === $listing_create_status || 'pending' === $listing_create_status ) {
-						if ( ! $default_expiration ) {
+						if ( $default_expiration <= 0 ) {
 							update_post_meta( $listing_id, '_never_expire', 1 );
 						} else {
 							$expiration_date = calc_listing_expiry_date( '', $default_expiration );
@@ -977,9 +977,10 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 			// TODO: Status has been migrated, remove related code.
 			update_post_meta( $listing_id, '_listing_status', 'post_status' );
 
-			$exp_days = get_term_meta( $directory_type, 'default_expiration', true );
-			if ( $exp_days <= 0 ) {
+			if ( directorist_get_default_expiration( $directory_type ) <= 0 ) {
 				update_post_meta( $listing_id, '_never_expire', 1 );
+			} else {
+				delete_post_meta( $listing_id, '_never_expire' );
 			}
 
 			do_action( 'atbdp_after_renewal', $listing_id );

--- a/includes/directorist-directory-functions.php
+++ b/includes/directorist-directory-functions.php
@@ -128,7 +128,7 @@ function directorist_get_listing_edit_status( $directory_id ) {
 }
 
 function directorist_get_default_expiration( $directory_id ) {
-	return directorist_get_directory_meta( $directory_id, 'default_expiration' );
+	return (int) directorist_get_directory_meta( $directory_id, 'default_expiration' );
 }
 
 function directorist_is_directory( $directory_id ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
During the listing renewal process, the never-expire meta is set to true. But in reality, it's supposed to either set the meta to true or delete if it's already true, based on the default expiration days condition.

## Any linked issues
Internal

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
