### PR TITLE
fix multisite deletion issue

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -12,6 +12,11 @@ include_once("directorist-base.php");
 wp_clear_scheduled_hook('directorist_hourly_scheduled_events');
 
 function directorist_uninstall() {
+
+    if( ! get_directorist_option('enable_uninstall',0) ) {
+        return;
+    }
+    
     global $wpdb;
 
     // Delete selected pages

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,15 +2,19 @@
 /**
  * @package Directorist
  */
-defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
-// Access the database via SQL
+defined('WP_UNINSTALL_PLUGIN') || exit;
+
 global $wpdb;
+
 include_once("directorist-base.php");
-$enable_uninstall = get_directorist_option('enable_uninstall',0);
+
 // Clear schedules
 wp_clear_scheduled_hook('directorist_hourly_scheduled_events');
-if(!empty($enable_uninstall)) {
-    // Delete selected pages.
+
+function directorist_uninstall() {
+    global $wpdb;
+
+    // Delete selected pages
     wp_delete_post(get_directorist_option('add_listing_page'), true);
     wp_delete_post(get_directorist_option('all_listing_page'), true);
     wp_delete_post(get_directorist_option('user_dashboard'), true);
@@ -29,25 +33,29 @@ if(!empty($enable_uninstall)) {
     wp_delete_post(get_directorist_option('transaction_failure_page'), true);
     wp_delete_post(get_directorist_option('privacy_policy'), true);
     wp_delete_post(get_directorist_option('terms_conditions'), true);
-    // Delete posts + data.
-    $wpdb->query( "DELETE FROM {$wpdb->posts} WHERE post_type IN ( 'at_biz_dir', 'atbdp_fields', 'atbdp_orders', 'atbdp_listing_review' );" );
 
-    //Delete all metabox
-    $wpdb->query("DELETE FROM {$wpdb->postmeta} WHERE post_id Not IN  (SELECT id FROM {$wpdb->posts})");
+    // Delete posts and data
+    $wpdb->query("DELETE FROM {$wpdb->posts} WHERE post_type IN ('at_biz_dir', 'atbdp_fields', 'atbdp_orders', 'atbdp_listing_review');");
 
-    //Delete term relationships
-    $wpdb->query("DELETE FROM {$wpdb->term_relationships} WHERE object_id Not IN  (SELECT id FROM {$wpdb->posts})");
+    // Delete all metabox
+    $wpdb->query("DELETE FROM {$wpdb->postmeta} WHERE post_id NOT IN (SELECT ID FROM {$wpdb->posts});");
 
-    //Delete all taxonomy
+    // Delete term relationships
+    $wpdb->query("DELETE FROM {$wpdb->term_relationships} WHERE object_id NOT IN (SELECT ID FROM {$wpdb->posts});");
+
+    // Delete all taxonomy
     $wpdb->query("DELETE FROM {$wpdb->term_taxonomy} WHERE taxonomy = 'at_biz_dir-location'");
     $wpdb->query("DELETE FROM {$wpdb->term_taxonomy} WHERE taxonomy = 'at_biz_dir-category'");
     $wpdb->query("DELETE FROM {$wpdb->term_taxonomy} WHERE taxonomy = 'at_biz_dir-tags'");
-    //Delete all term meta
-    $wpdb->query("DELETE FROM {$wpdb->termmeta} WHERE term_id Not IN  (SELECT term_id FROM {$wpdb->term_taxonomy})");
-    $wpdb->query("DELETE FROM {$wpdb->terms} WHERE term_id Not IN  (SELECT term_id FROM {$wpdb->term_taxonomy})");
-    //Delete raview database
+
+    // Delete all term meta
+    $wpdb->query("DELETE FROM {$wpdb->termmeta} WHERE term_id NOT IN (SELECT term_id FROM {$wpdb->term_taxonomy});");
+    $wpdb->query("DELETE FROM {$wpdb->terms} WHERE term_id NOT IN (SELECT term_id FROM {$wpdb->term_taxonomy});");
+
+    // Delete review database
     $wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}atbdp_review");
-    //Delete usermeta.
+
+    // Delete usermeta
     $wpdb->query("DELETE FROM $wpdb->usermeta WHERE meta_key LIKE '%atbdp%';");
     $wpdb->query("DELETE FROM $wpdb->usermeta WHERE meta_key = 'pro_pic';");
 
@@ -76,7 +84,23 @@ if(!empty($enable_uninstall)) {
         'at_biz_dir-location_children',
         'at_biz_dir-category_children',
     );
+
     foreach ($atbdp_settings as $settings) {
         delete_option($settings);
     }
+}
+
+if (is_multisite()) {
+    $original_blog_id = get_current_blog_id();
+    $sites = get_sites();
+
+    foreach ($sites as $site) {
+        switch_to_blog($site->blog_id);
+        directorist_uninstall();
+        restore_current_blog();
+    }
+
+    switch_to_blog($original_blog_id);
+} else {
+    directorist_uninstall();
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

In the multi-network setup, Directorist data doesn't fully clean up despite enabling the "Remove Data on Uninstall" option in settings. Even after deactivating and deleting Directorist from both the subdirectory and network site with the option enabled, and then removing the plugin at the network level, previous listings persist upon reinstallation.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
