### PR TITLE
fix: Connect the renewed email with hooks

### DIFF
--- a/includes/classes/class-cron.php
+++ b/includes/classes/class-cron.php
@@ -373,6 +373,7 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
 							'_renewal_reminder_sent' => 0,
 						),
 					) );
+					do_action( 'atbdp_after_renewal', $listing->ID );
 				}
 			}
 		}

--- a/includes/classes/class-email.php
+++ b/includes/classes/class-email.php
@@ -34,6 +34,8 @@ if ( ! class_exists( 'ATBDP_Email' ) ) :
 			add_action( 'atbdp_listing_expired', array( $this, 'notify_owner_listing_expired' ) );
 			// @todo; send admin a notification too for expired listings. Think about it later or give admin option??
 			add_action( 'atbdp_send_renewal_reminder', array( $this, 'notify_owner_to_renew' ) );
+			/*Listing Status changed from expired to renewed*/
+			add_action( 'atbdp_after_renewal', array( $this, 'notify_owner_listing_renewed' ) );
 			/*Fire up email for deleted/trashed listings*/
 			add_action( 'atbdp_deleted_expired_listings', array( $this, 'notify_owner_listing_deleted' ) );
 			add_action( 'atbdp_deleted_expired_listings', array( $this, 'notify_admin_listing_deleted' ) );

--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -5598,6 +5598,10 @@ Please remember that your order may be canceled if you do not make your payment 
                     'value' => 'remind_to_renew',
                     'label' => __('Remind to renew', 'directorist'),
                 ),
+                array(
+                    'value' => 'listing_renewed',
+                    'label' => __('Listing Renewed', 'directorist'),
+                ),
             ));
         }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
"Listing Renewed" email was not triggering when a listing was renewed automatically.
We had a hook to trigger this "atbdp_after_renewal" but it was not connected to the function "notify_owner_listing_renewed".

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
