### PR TITLE
fix: default user profile page

### DIFF
--- a/includes/model/ListingAuthor.php
+++ b/includes/model/ListingAuthor.php
@@ -357,6 +357,10 @@ class Directorist_Listing_Author {
 			return ATBDP()->helper->guard( array('type' => 'auth') );
 		}
 
+		if ( ! is_user_logged_in() && ! $this->id ) {
+			return ATBDP()->helper->guard( array('type' => '404') );
+		}
+
 		return Helper::get_template_contents( 'author-contents', array( 'author' => $this ) );
 	}
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
When a user is logged out, Default author profile page displays the Admin profile.
http://directoristgit.local/author-profile/

## Any linked issue
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
