### PR TITLE
Fixed jQuery 3 compatibility issue

### DIFF
--- a/assets/js/all-listings.js
+++ b/assets/js/all-listings.js
@@ -2244,7 +2244,7 @@ window.addEventListener('DOMContentLoaded', function () {
           var commentID = $form.find('input[name="comment_id"]').val();
           var $wrap = $('#div-comment-' + commentID);
           $wrap.addClass('directorist-comment-edit-request');
-          updateComment.success(function (data, status, request) {
+          updateComment.done(function (data, status, request) {
             if (typeof data !== 'string' && !data.success) {
               $wrap.removeClass('directorist-comment-edit-request');
               CommentEditHandler.showError($form, data.data.html);
@@ -2321,7 +2321,7 @@ window.addEventListener('DOMContentLoaded', function () {
           });
           $('#comment').prop('disabled', true);
           form.find('[type="submit"]').prop('disabled', true).val('loading');
-          do_comment.success(function (data, status, request) {
+          do_comment.done(function (data, status, request) {
             var body = $('<div></div>');
             body.append(data);
             var comment_section = '.directorist-review-container';

--- a/assets/js/single-listing.js
+++ b/assets/js/single-listing.js
@@ -793,7 +793,7 @@ window.addEventListener('DOMContentLoaded', function () {
           var commentID = $form.find('input[name="comment_id"]').val();
           var $wrap = $('#div-comment-' + commentID);
           $wrap.addClass('directorist-comment-edit-request');
-          updateComment.success(function (data, status, request) {
+          updateComment.done(function (data, status, request) {
             if (typeof data !== 'string' && !data.success) {
               $wrap.removeClass('directorist-comment-edit-request');
               CommentEditHandler.showError($form, data.data.html);
@@ -870,7 +870,7 @@ window.addEventListener('DOMContentLoaded', function () {
           });
           $('#comment').prop('disabled', true);
           form.find('[type="submit"]').prop('disabled', true).val('loading');
-          do_comment.success(function (data, status, request) {
+          do_comment.done(function (data, status, request) {
             var body = $('<div></div>');
             body.append(data);
             var comment_section = '.directorist-review-container';

--- a/assets/src/js/public/components/review/advanced-review.js
+++ b/assets/src/js/public/components/review/advanced-review.js
@@ -110,7 +110,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
                 $wrap.addClass('directorist-comment-edit-request');
 
-                updateComment.success((data, status, request) => {
+                updateComment.done((data, status, request) => {
                     if (typeof data !== 'string' && !data.success) {
                         $wrap.removeClass('directorist-comment-edit-request');
                         CommentEditHandler.showError($form, data.data.html);
@@ -210,7 +210,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 $('#comment').prop('disabled', true);
                 form.find('[type="submit"]').prop('disabled', true).val('loading');
 
-                do_comment.success((data, status, request) => {
+                do_comment.done((data, status, request) => {
                     var body = $('<div></div>');
                     body.append(data);
                     var comment_section = '.directorist-review-container';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
jQuery `$.ajax.success` has been deprecated which causes the issue.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
