### PR TITLE
add: filter to enable/disable notification to owner on order created

### DIFF
--- a/includes/classes/class-email.php
+++ b/includes/classes/class-email.php
@@ -465,6 +465,21 @@ This email is sent automatically for information purpose only. Please do not res
 				return false;
 			}
 
+			/**
+			 * Filters whether to send an email notification to the owner when an order is created.
+			 *
+			 * This filter allows modification of the logic determining whether an email notification
+			 * should be sent to the owner of the listing when an order is created. By default, the notification
+			 * will be sent (true). Developers can return false to prevent the notification from being sent.
+			 *
+			 * @since 7.11.1
+			 *
+			 * @param bool  $send_notification Whether to send the email notification. Default is true.
+			 * @param int   $order_id          The ID of the created order.
+			 * @param int   $listing_id        The ID of the listing associated with the order.
+			 *
+			 * @return bool Filtered value of $send_notification.
+			 */
 			if ( ! apply_filters( 'directorist_email_notification_to_owner_on_order_created', true, $order_id, $listing_id ) ) {
 				return false;
 			}

--- a/includes/classes/class-email.php
+++ b/includes/classes/class-email.php
@@ -465,6 +465,10 @@ This email is sent automatically for information purpose only. Please do not res
 				return false;
 			}
 
+			if ( ! apply_filters( 'directorist_email_notification_to_owner_on_order_created', true, $order_id, $listing_id ) ) {
+				return false;
+			}
+
 			$user = $this->get_owner( $listing_id );
 			// Send email according to the type of the payment that user used during checkout. get email template from the db.
 			$offline = ( ! empty( $offline ) ) ? '_offline' : '';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Added this filter hook on request - "directorist_email_notification_to_owner_on_order_created"


## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
