### PR TITLE
Fixed listing form preview disabled redirect issue

### DIFF
--- a/assets/js/add-listing.js
+++ b/assets/js/add-listing.js
@@ -773,7 +773,7 @@ $(document).ready(function () {
                 window.location.href = decodeURIComponent(redirect_url);
               } else {
                 $notification.show().html("<span class=\"atbdp_success\">".concat(response.success_msg, "</span>"));
-                window.location.href = joinQueryString(response.redirect_url, is_edited);
+                window.location.href = joinQueryString(decodeURIComponent(response.redirect_url), is_edited);
               }
             }
           }

--- a/assets/src/js/global/add-listing.js
+++ b/assets/src/js/global/add-listing.js
@@ -15,7 +15,7 @@ const localized_data = directorist.add_listing_data;
  * @param string queryString
  * @return string
  */
- function joinQueryString( url, queryString ) {
+function joinQueryString( url, queryString ) {
     return url.match( /[?]/ ) ? `${url}&${queryString}` : `${url}?${queryString}`;
 }
 
@@ -736,7 +736,7 @@ $(document).ready(function () {
                                 window.location.href = decodeURIComponent(redirect_url);
                             } else {
                                 $notification.show().html(`<span class="atbdp_success">${response.success_msg}</span>`);
-                                window.location.href = joinQueryString( response.redirect_url, is_edited );
+                                window.location.href = joinQueryString( decodeURIComponent( response.redirect_url ), is_edited );
                             }
                         }
                     }

--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -444,9 +444,7 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 					$data['success_msg'] = __( 'Payment required! Redirecting to checkout...', 'directorist' );
 				}
 
-				if ( $preview_enable ) {
-					$data['preview_mode'] = true;
-				}
+				$data['preview_mode'] = $preview_enable;
 
 				if ( ! empty( $posted_data['listing_id'] ) ) {
 					$data['edited_listing'] = true;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
Internal

## Any linked issues
- Turning off listing preview can not redirect to the correct page (page not found)

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
