### PR TITLE
Single listing header migration (from v8 to v7) & Fixed empty img issue on listing-slider

### DIFF
--- a/includes/classes/class-upgrade.php
+++ b/includes/classes/class-upgrade.php
@@ -42,10 +42,12 @@ class ATBDP_Upgrade
 	public function migrate_single_listing_header_data() {
 		// Check if migration has already been completed.
 		if (
-			get_option( 'v7_single_listing_header_migration', false ) ||
-			! current_user_can( 'manage_options' ) ||
-			( ! get_option( 'directorist_builder_header_migrated', false ) &&
-			get_option( 'directorist_db_version', false ) <= '8.0.0' )
+			get_option( 'v7_single_listing_header_migration', false ) 
+			|| ! current_user_can( 'manage_options' ) 
+			|| ( 
+				! get_option( 'directorist_builder_header_migrated', false ) 
+				&& version_compare( get_option( 'directorist_db_version', false ), '8.0.0', '<=' ) 
+			)
 		) {
 			return;
 		}

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -501,7 +501,7 @@ class Directorist_Single_Listing {
 
 		// Get the gallery images
 		$listing_img  = get_post_meta( $listing_id, '_listing_img', true );
-		$listing_imgs = ( ! empty( $listing_img ) ) ? $listing_img : array();
+		$listing_imgs = ! empty( $listing_img ) ? ( ! is_array( $listing_img ) ? array( $listing_img ) : $listing_img ) : array();
 		$image_links  = array(); // define a link placeholder variable
 
 		foreach ( $listing_imgs as $img_id ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ X] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Single listing empty img slider issue
2. Done Single listing header backward combability/migration
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
