### PR TITLE
Added backward compatibility support for custom Directorist templates in WordPress themes to prevent errors in the latest version.

### DIFF
--- a/includes/model/ListingForm.php
+++ b/includes/model/ListingForm.php
@@ -462,6 +462,7 @@ class Directorist_Listing_Form {
 			'display_privacy'         => (bool) get_directorist_type_option( $type, 'listing_privacy', 1 ),
 			'privacy_is_required'     => get_directorist_type_option( $type, 'require_privacy', 1 ),
 			'privacy_checked'         => (bool) get_post_meta( $p_id, '_privacy_policy', true ),
+			'display_terms'           => false,
 			'terms_checked'           => (bool) get_post_meta( $p_id, '_t_c_check', true ),
 			'submit_label'            => get_directorist_type_option( $type, 'submit_button_label', __( 'Save & Preview', 'directorist' ) ),
 		);

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -611,6 +611,7 @@ class Directorist_Single_Listing {
 
 		$args = array(
 			'listing'    => $this,
+			'has_slider' => true,
 			'data'       => $this->get_slider_data( $slider ),
 		);
 

--- a/includes/review/class-builder.php
+++ b/includes/review/class-builder.php
@@ -82,6 +82,28 @@ class Builder {
 		return $this->get_field( 'website', 'placeholder', $default );
 	}
 
+	/**
+	 * Get the label for the comment field.
+	 *
+	 * @deprecated 8.0 Use get_comment_field_label() instead.
+	 * @param string $default Default label text if not set.
+	 * @return string The label for the comment field.
+	 */
+	public function get_comment_label( $default = '' ) {
+		_deprecated_function( __METHOD__, '8.0' );
+		return $this->get_comment_field_label( $default );
+	}
+
+	/**
+	 * Get comment field label.
+	 *
+	 * @param string $default Default label text.
+	 * @return string
+	 */
+	public function get_comment_field_label( $default = '' ) {
+		return $this->get_field( 'comment_label', $default );
+	}
+
 	public function get_comment_placeholder( $default = '' ) {
 		return $this->get_field( 'comment', 'placeholder', $default );
 	}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ x ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Override all possible templates from v7 to theme, then activate directorist v7 and import demo data.      
After that, update Directorist v7 to v8 and initiate the migration from the admin notice. When you look at Directorist-related components, several php issues arise.
2. Here is the task: https://taiga-sovware-u10698.vm.elestio.app/project/directorist-1/task/39
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
