### PR TITLE
Fix mobile date picker display and instant search behavior

### DIFF
--- a/assets/src/js/public/components/instantSearch.js
+++ b/assets/src/js/public/components/instantSearch.js
@@ -144,6 +144,12 @@ import initSearchCategoryCustomFields from './category-custom-fields';
 				scrollingPage = 1;
 				infinitePaginationCompleted = false;
 			},
+			error: function () {
+				// The URL is updated before the request. If an intermediary blocks
+				// the AJAX POST, reload that URL so server-side filtering still works.
+				lastSubmittedFormData = '';
+				window.location.assign(window.location.href);
+			},
 		});
 	}
 
@@ -955,7 +961,7 @@ import initSearchCategoryCustomFields from './category-custom-fields';
 	// sidebar on change searching - radio/checkbox/location/range
 	$('body').on(
 		'change',
-		".directorist-instant-search .listing-with-sidebar input[type='checkbox'],.directorist-instant-search .listing-with-sidebar input[type='radio'], .directorist-instant-search .listing-with-sidebar input[type='time'], .directorist-instant-search .listing-with-sidebar input[type='date'], .directorist-instant-search .listing-with-sidebar .directorist-custom-range-slider__wrap .directorist-custom-range-slider__range, .directorist-instant-search .listing-with-sidebar .directorist-search-location .location-name",
+		".directorist-instant-search .listing-with-sidebar input[type='checkbox'],.directorist-instant-search .listing-with-sidebar input[type='radio'], .directorist-instant-search .listing-with-sidebar .directorist-custom-range-slider__wrap .directorist-custom-range-slider__range, .directorist-instant-search .listing-with-sidebar .directorist-search-location .location-name",
 		debounce(function (e) {
 			e.preventDefault();
 			var searchElm = $(this).closest('.listing-with-sidebar');
@@ -964,6 +970,45 @@ import initSearchCategoryCustomFields from './category-custom-fields';
 			performInstantSearchWithRequiredValue(searchElm);
 		}, 250)
 	);
+
+	const dateTimeInputSelector =
+		".directorist-instant-search .listing-with-sidebar input[type='time'], .directorist-instant-search .listing-with-sidebar input[type='date']";
+
+	const performDateTimeInstantSearch = debounce(function (input) {
+		const searchElm = $(input).closest('.listing-with-sidebar');
+
+		performInstantSearchWithRequiredValue(searchElm);
+	}, 250);
+
+	// iOS date/time pickers can emit change while their native UI is still open.
+	// Wait for focus to leave the input before refreshing the listings so the
+	// picker is not interrupted. Android and desktop keep instant search on
+	// change because their native pickers commit the value before returning.
+	$('body').on('change', dateTimeInputSelector, function (e) {
+		e.preventDefault();
+
+		const isIOSDevice =
+			/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+			(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+		if (isIOSDevice) {
+			$(this).data('directorist-ios-date-time-changed', true);
+			return;
+		}
+
+		performDateTimeInstantSearch(this);
+	});
+
+	$('body').on('blur', dateTimeInputSelector, function () {
+		const input = $(this);
+
+		if (!input.data('directorist-ios-date-time-changed')) {
+			return;
+		}
+
+		input.removeData('directorist-ios-date-time-changed');
+		performDateTimeInstantSearch(this);
+	});
 
 	// sidebar on change searching - zipcode/location
 	$('body').on(

--- a/assets/src/scss/component/_search-home.scss
+++ b/assets/src/scss/component/_search-home.scss
@@ -77,6 +77,27 @@
 		}
 	}
 
+	// Native date inputs do not expose reliable placeholder text on mobile.
+	// Use the field label as a tappable-area-safe placeholder until focus/value.
+	@media screen and (max-width: 767px) {
+		.directorist-search-form-top &.directorist-date {
+			.directorist-search-field__label {
+				opacity: 1;
+				pointer-events: none;
+			}
+
+			&:not(.input-has-value):not(.input-is-focused)
+				.directorist-search-field__input[type='date'] {
+				color: transparent;
+				-webkit-text-fill-color: transparent;
+
+				&::-webkit-datetime-edit {
+					color: transparent;
+				}
+			}
+		}
+	}
+
 	&.input-has-value,
 	&.input-is-focused {
 		.directorist-search-field__input {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Open the All Listings page for a directory containing a date search field, then switch to a mobile viewport or use an Android/iOS device.
2. Confirm the empty date field displays the `Date` label without overlapping the browser's native date template.
3. Select a date on Android and confirm instant search runs after the native picker commits the value.
4. Select a date on iOS and confirm the native picker remains open until focus leaves the field, then instant search runs.
5. Confirm a failed instant-search AJAX request falls back to loading the filtered URL instead of leaving stale listing results.
6. Confirm desktop date-field presentation remains unchanged.

Validation completed:
- `npm run build-legacy` passed with existing asset-size warnings.
- `git diff --check` passed.
- Empty, focused, selected, instant-search, 440px mobile, and 1440px desktop states were browser-tested.
- Generated build files are intentionally excluded from this PR.

## Any linked issues
Fixes #
https://team.sovware.com/support/directorist/3159
## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
