### PR TITLE
Fix listing URL validation without explicit schemes

### DIFF
--- a/includes/fields/class-directorist-url-field.php
+++ b/includes/fields/class-directorist-url-field.php
@@ -13,9 +13,15 @@ class Url_Field extends Base_Field {
     public $type = 'url';
 
     public function validate( $posted_data ) {
-        $value = $this->sanitize( $posted_data );
+        $value      = $this->sanitize( $posted_data );
+        $parsed_url = wp_parse_url( $value );
 
-        if ( ! wp_http_validate_url( $value ) ) {
+        if (
+            ! filter_var( $value, FILTER_VALIDATE_URL ) ||
+            false === $parsed_url ||
+            isset( $parsed_url['user'] ) ||
+            isset( $parsed_url['pass'] )
+        ) {
             $this->add_error( __( 'Invalid URL.', 'directorist' ) );
 
             return false;
@@ -30,7 +36,7 @@ class Url_Field extends Base_Field {
             return $value;
         }
 
-        return esc_url_raw( $value );
+        return esc_url_raw( $value, [ 'http', 'https' ] );
     }
 }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Listing website fields were validated with `wp_http_validate_url()`, which is intended for outbound HTTP request safety and performs a DNS lookup. As a result, a syntactically valid URL could return `Invalid URL` when the domain could not be resolved during submission. This was especially confusing when users entered common scheme-less values such as `www.example.com`.

This change:

- normalizes scheme-less values through `esc_url_raw()` with an explicit HTTP/HTTPS allowlist;
- validates URL syntax without requiring DNS resolution;
- rejects embedded usernames or passwords to prevent misleading user-info URLs;
- continues to reject malformed values and unsupported protocols.

How to reproduce the issue or how to test the changes:

1. Open the Add Listing form and enter a website value without a scheme, such as `www.example.com`.
2. Submit the listing and confirm the URL is accepted and normalized to `http://www.example.com`.
3. Confirm syntactically valid URLs do not fail solely because their hosts cannot be resolved during submission.
4. Confirm malformed values and unsupported protocols such as `ftp://example.com` are rejected.
5. Confirm credential-bearing or deceptive values such as `https://trusted.example@evil.example` are rejected.

Validation performed:

- `php -l includes/fields/class-directorist-url-field.php`
- `git diff --check -- includes/fields/class-directorist-url-field.php`

Before
https://prnt.sc/m4zOLpPuKrjE
After
https://www.loom.com/share/b2ac8de247ce4c42a57722b70f286d60

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
