### PR TITLE
Allow inactive themes to update from Themes & Extensions

### DIFF
--- a/views/admin-templates/theme-extensions/my-themes-extensions/themes-tab.php
+++ b/views/admin-templates/theme-extensions/my-themes-extensions/themes-tab.php
@@ -118,6 +118,13 @@
                         </div>
                     </figcaption>
                 </figure>
+
+                <?php if ( ! empty( $_theme_args['is_installed'] ) && ! empty( $_theme_args['has_update'] ) && ! empty( $_theme_args['stylesheet'] ) ) : ?>
+                <div class="theme-card__footer">
+                    <p class="theme-update theme-update--available"><?php esc_html_e( 'Update available', 'directorist' )?></p>
+                    <a href="#" class="theme-update-btn" data-target="<?php echo esc_attr( $_theme_args['stylesheet'] ); ?>"><?php echo esc_html( $args['is_beta'] ? 'Update Beta' : 'Update' ); ?></a>
+                </div>
+                <?php endif;?>
             </div>
             <?php endforeach;?>
         </div>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Install a Directorist theme included in the authenticated subscription, keep another theme active, and make an update available for the inactive Directorist theme.
2. Go to **Directorist > Themes & Extensions**, open the **Themes** tab, and locate the installed inactive theme under **Available in your subscription**.
3. Confirm that **Activate**, **Live Preview**, and **Update** are all available. The Update action must target that inactive theme's stylesheet and use the existing theme-update request.
4. Confirm that an installed theme without an update does not show Update, an uninstalled theme still shows Install, and the active-theme behavior is unchanged.

Verification completed:

- LocalWP UI reproduction with inactive dJobs: Activate, Live Preview, and Update were present, with `data-target="djobs"`.
- PHP syntax check passed for the changed template.
- Targeted `composer phpcs` passed under PHP 8.2.
- Render-state matrix passed for inactive/updatable, inactive/current, and uninstalled themes.
- `git diff --check` passed.

## Any linked issues
Fixes #690

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
