### PR TITLE
Order listing-card locations by hierarchy

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -140,6 +140,78 @@ function directorist_has_listing_thumbnail( $listing = null ) {
     return (bool) directorist_get_listing_thumbnail_id( $listing );
 }
 
+function directorist_sort_location_terms_by_hierarchy( $terms ) {
+    if ( ! is_array( $terms ) || count( $terms ) < 2 ) {
+        return $terms;
+    }
+
+    $sort_data = [];
+
+    foreach ( $terms as $term ) {
+        $ancestors = get_ancestors( $term->term_id, ATBDP_LOCATION, 'taxonomy' );
+        $root_id   = empty( $ancestors ) ? $term->term_id : end( $ancestors );
+        $root_term = $root_id === $term->term_id ? $term : get_term( $root_id, ATBDP_LOCATION );
+
+        $sort_data[ $term->term_id ] = [
+            'root_id'   => (int) $root_id,
+            'root_name' => ! is_wp_error( $root_term ) && $root_term ? $root_term->name : '',
+            'depth'     => count( $ancestors ),
+            'name'      => $term->name,
+        ];
+    }
+
+    usort(
+        $terms,
+        function ( $first_term, $second_term ) use ( $sort_data ) {
+            $first  = $sort_data[ $first_term->term_id ];
+            $second = $sort_data[ $second_term->term_id ];
+
+            $root_name_comparison = strcasecmp( $first['root_name'], $second['root_name'] );
+            if ( 0 !== $root_name_comparison ) {
+                return $root_name_comparison;
+            }
+
+            if ( $first['root_id'] !== $second['root_id'] ) {
+                return $first['root_id'] <=> $second['root_id'];
+            }
+
+            if ( $first['depth'] !== $second['depth'] ) {
+                return $second['depth'] <=> $first['depth'];
+            }
+
+            $name_comparison = strcasecmp( $first['name'], $second['name'] );
+            if ( 0 !== $name_comparison ) {
+                return $name_comparison;
+            }
+
+            return $first_term->term_id <=> $second_term->term_id;
+        }
+    );
+
+    return $terms;
+}
+
 function directorist_the_locations( $before = '', $sep = ', ', $after = '', $listing_id = null ) {
-    the_terms( $listing_id, ATBDP_LOCATION, $before, $sep, $after );
+    $terms = get_the_terms( $listing_id, ATBDP_LOCATION );
+
+    if ( is_wp_error( $terms ) || empty( $terms ) ) {
+        return;
+    }
+
+    $links = [];
+    $terms = directorist_sort_location_terms_by_hierarchy( $terms );
+
+    foreach ( $terms as $term ) {
+        $link = get_term_link( $term, ATBDP_LOCATION );
+        if ( is_wp_error( $link ) ) {
+            return;
+        }
+
+        $links[] = '<a href="' . esc_url( $link ) . '" rel="tag">' . $term->name . '</a>';
+    }
+
+    $term_links = apply_filters( 'term_links-' . ATBDP_LOCATION, $links );
+    $term_list  = $before . implode( $sep, $term_links ) . $after;
+
+    echo apply_filters( 'the_terms', $term_list, ATBDP_LOCATION, $before, $sep, $after ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Preserve the core the_terms() filter contract.
 }

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -207,7 +207,7 @@ function directorist_the_locations( $before = '', $sep = ', ', $after = '', $lis
             return;
         }
 
-        $links[] = '<a href="' . esc_url( $link ) . '" rel="tag">' . $term->name . '</a>';
+        $links[] = '<a href="' . esc_url( $link ) . '" rel="tag">' . esc_html( $term->name ) . '</a>';
     }
 
     $term_links = apply_filters( 'term_links-' . ATBDP_LOCATION, $links );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Create at least one three-level location hierarchy, such as Country > State > City, and assign all three terms to a published listing.
2. Add the Location widget to the active all-listing card layout and open the All Listings page.
3. Confirm the assigned locations render consistently as City, State, Country. Links, the configured separator, and the existing `term_links-at_biz_dir-location` and `the_terms` filters must continue to work.
4. Assign terms from multiple branches and multiple root locations. Confirm roots remain grouped, deeper assigned terms appear first within each group, and names and term IDs provide stable fallback ordering.
5. Assign a child and grandchild without assigning their root. Confirm the assigned terms are ordered but the unassigned ancestor is not added. Also confirm empty-location cards emit no location output and no term is duplicated.

Verification completed:

- LocalWP all-listing card rendered 11 assigned terms across multiple branches and roots in the expected hierarchy order.
- The unassigned test ancestor was omitted, all 11 links were valid, and all 11 labels were unique.
- Custom before/separator/after values and both native term-output filters were verified.
- Empty-location output was verified.
- PHP syntax, targeted `composer phpcs`, and `git diff --check` passed.

## Any linked issues
Fixes #1681

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
