### PR TITLE
Preserve IIS temporary paths during uploads and directory import

### DIFF
--- a/includes/classes/class-ajax-handler.php
+++ b/includes/classes/class-ajax-handler.php
@@ -953,8 +953,7 @@ if ( ! class_exists( 'ATBDP_Ajax_Handler' ) ) :
                     $upload_token = isset( $_POST['upload_token'] ) ? sanitize_text_field( wp_unslash( $_POST['upload_token'] ) ) : '';
                     $token_data   = $upload_token ? get_transient( 'directorist_file_upload_' . $upload_token ) : false;
 
-                    if (
-                        empty( $token_data )
+                    if ( empty( $token_data )
                         || ! is_array( $token_data )
                         || (int) ( $token_data['directory'] ?? 0 ) !== $directory
                         || (string) ( $token_data['field_key'] ?? '' ) !== $field_id
@@ -985,7 +984,7 @@ if ( ! class_exists( 'ATBDP_Ajax_Handler' ) ) :
                 }
 
                 $field_id   = sanitize_text_field( $field_config['field_key'] );
-                $fixed_file = ( ! empty( $_FILES[ $field_id . 'async-upload' ] ) ) ? directorist_clean( wp_unslash( $_FILES[ $field_id . 'async-upload' ] ) ) : '';
+                $fixed_file = ( ! empty( $_FILES[ $field_id . 'async-upload' ] ) ) ? directorist_clean( $_FILES[ $field_id . 'async-upload' ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Unslashing corrupts Windows upload paths in raw $_FILES data.
 
                 if ( empty( $fixed_file ) ) {
                     throw new \Exception( __( 'No file supplied.', 'directorist' ), 400 );

--- a/includes/modules/multi-directory-setup/class-multi-directory-manager.php
+++ b/includes/modules/multi-directory-setup/class-multi-directory-manager.php
@@ -530,7 +530,7 @@ class Multi_Directory_Manager {
 
         $term_id        = ( ! empty( $_POST[ 'term_id' ] ) ) ? absint( $_POST[ 'term_id' ] ) : 0;
         $directory_name = ( ! empty( $_POST[ 'directory-name' ] ) ) ? sanitize_text_field( wp_unslash( $_POST[ 'directory-name' ] ) ) : '';
-        $json_file      = ( ! empty( $_FILES[ 'directory-import-file' ] ) ) ? directorist_clean( wp_unslash( $_FILES[ 'directory-import-file' ] ) ) : '';
+        $json_file      = ( ! empty( $_FILES[ 'directory-import-file' ] ) ) ? directorist_clean( $_FILES[ 'directory-import-file' ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Unslashing corrupts Windows upload paths in raw $_FILES data.
 
         // Validation
         $response = [


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. On Windows/IIS, configure a custom File field in a directory and upload a valid file through the asynchronous listing-form uploader.
2. Confirm the raw temporary path, for example `C:\Program Files\PHPv8.1\upload\phpAC39.tmp`, retains every backslash before `wp_handle_upload()` and the upload succeeds.
3. Go to **Directorist > Directory Builder**, import a valid directory JSON file, and confirm the import succeeds without corrupting the uploaded temporary path.
4. Repeat both flows on a Unix host and confirm custom-file upload, directory import, and the existing listing-image REST upload still succeed.
5. Confirm nonce/capability checks, recursive cleaning, size restrictions, supported MIME validation, and WordPress upload validation remain active.

Verification completed:

- The reported Windows temporary path remained byte-for-byte unchanged; the previous `wp_unslash()` behavior reproduced the corruption.
- Unix temporary paths remained unchanged.
- LocalWP directory JSON multipart import succeeded with HTTP 200 and created the test directory.
- LocalWP asynchronous custom-field multipart upload succeeded with HTTP 201.
- LocalWP listing-image REST upload succeeded with HTTP 200.
- Both changed PHP files passed syntax checks and PHPCS with zero errors; the pre-existing warning count remained unchanged.
- `git diff --check` passed, and all temporary database, plugin, directory, field, and upload-file fixtures were removed.

## Any linked issues
Fixes #1356

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
