### PR TITLE
Correct the location edit back-link label

### DIFF
--- a/includes/classes/class-custom-taxonomy.php
+++ b/includes/classes/class-custom-taxonomy.php
@@ -535,6 +535,7 @@ if ( ! class_exists( 'ATBDP_Custom_Taxonomy' ) ) :
                 'singular_name'     => _x( 'Listing Location', 'Location singular name', 'directorist' ),
                 'search_items'      => __( 'Search Location', 'directorist' ),
                 'all_items'         => __( 'All Locations', 'directorist' ),
+                'back_to_items'     => __( 'Go to Locations', 'directorist' ),
                 'parent_item'       => __( 'Parent Location', 'directorist' ),
                 'parent_item_colon' => __( 'Parent Location:', 'directorist' ),
                 'edit_item'         => __( 'Edit Location', 'directorist' ),


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Go to **Directorist > Locations** and open an existing location from the taxonomy list.
2. Click **Update** without changing the location.
3. Confirm the success notice reads **Location updated. Go to Locations** rather than using the Categories fallback.
4. Click **Go to Locations** and confirm it returns to the Directorist location taxonomy list for the listing post type.
5. Open and update a Directorist category and confirm its existing category-specific label remains unchanged.

Verification completed:

- The exact LocalWP list → edit → update path displayed **Go to Locations**.
- The rendered link returned to `edit-tags.php?taxonomy=at_biz_dir-location&post_type=at_biz_dir`.
- The category taxonomy continued to expose its existing **Go to Categories** label.
- PHP syntax, targeted PHPCS, and `git diff --check` passed.

## Any linked issues
Fixes #961

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
