### PR TITLE
Filter popular categories before applying the result limit

### DIFF
--- a/includes/model/SearchForm.php
+++ b/includes/model/SearchForm.php
@@ -833,27 +833,42 @@ class Directorist_Listing_Search_Form {
         $top_categories = [];
 
         $args = [
-            'type'          => ATBDP_POST_TYPE,
-            'parent'        => 0,
-            'orderby'       => 'count',
-            'order'         => 'desc',
-            'hide_empty'    => 1,
-            'number'        => (int) $this->popular_cat_num,
-            'taxonomy'      => ATBDP_CATEGORY,
-            'no_found_rows' => true,
+            'type'                                  => ATBDP_POST_TYPE,
+            'orderby'                               => 'count',
+            'order'                                 => 'desc',
+            'hide_empty'                            => 1,
+            'hierarchical'                          => false,
+            'number'                                => (int) $this->popular_cat_num,
+            'taxonomy'                              => ATBDP_CATEGORY,
+            'no_found_rows'                         => true,
+            'directorist_popular_categories_query' => true,
+            'meta_query'                            => [
+                'relation' => 'OR',
+                [
+                    'key'     => '_directory_type_' . absint( $this->listing_type ),
+                    'compare' => 'EXISTS',
+                ],
+                [
+                    'key'     => '_directory_type',
+                    'value'   => 'i:' . absint( $this->listing_type ) . ';',
+                    'compare' => 'LIKE',
+                ],
+            ],
         ];
 
-        $cats = get_categories( $args );
-
-        foreach ( $cats as $cat ) {
-            $directory_type      = get_term_meta( $cat->term_id, '_directory_type', true );
-            $directory_type      = ! empty( $directory_type ) ? (array) $directory_type : [];
-            $listing_type_id     = $this->listing_type;
-
-            if ( in_array( $listing_type_id, $directory_type ) ) {
-                $top_categories[] = $cat;
+        $root_categories_only = static function ( $clauses, $taxonomies, $query_args ) {
+            if ( empty( $query_args['directorist_popular_categories_query'] ) || ! in_array( ATBDP_CATEGORY, $taxonomies, true ) ) {
+                return $clauses;
             }
-        }
+
+            $clauses['where'] .= ' AND tt.parent = 0';
+
+            return $clauses;
+        };
+
+        add_filter( 'terms_clauses', $root_categories_only, 10, 3 );
+        $top_categories = get_categories( $args );
+        remove_filter( 'terms_clauses', $root_categories_only, 10 );
 
         return $top_categories;
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Create two directory types and assign more high-count root categories to the second directory than the configured Popular Categories limit.
2. Assign indexed-only, legacy-only, and dual-key root categories to the first directory, and add an empty category plus a high-count child category.
3. Open the first directory's search page and confirm the configured number of non-empty root categories is returned in count-descending order, without duplicates or categories from the second directory.
4. Inspect the term query and confirm directory meta and `tt.parent = 0` are applied before the bounded `LIMIT` clause.

The directory constraint now runs inside the term query before the result limit. It supports the indexed `_directory_type_<id>` key and the legacy serialized `_directory_type` key, while preserving root-only, non-empty, count-descending behavior.

## Any linked issues
Fixes #820

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
