### PR TITLE
feat(order): add prepaid status

### DIFF
--- a/includes/enums/order/status.php
+++ b/includes/enums/order/status.php
@@ -6,6 +6,7 @@ defined( "ABSPATH" ) || exit;
 
 class Status {
     const PENDING   = 'pending';
+    const PREPAID   = 'prepaid';
     const PAID      = 'paid';
     const FAILED    = 'failed';
     const CANCELLED = 'cancelled';
@@ -16,6 +17,7 @@ class Status {
     public static function all() {
         return [
             self::PENDING,
+            self::PREPAID,
             self::PAID,
             self::FAILED,
             self::CANCELLED,

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -45,6 +45,7 @@ function atbdp_get_payment_statuses() {
     $statuses = [
         'created' => __( "Created", 'directorist' ),
         'pending' => __( "Pending", 'directorist' ),
+        'prepaid' => __( "Prepaid", 'directorist' ),
         'completed' => __( "Completed", 'directorist' ),
         'failed' => __( "Failed", 'directorist' ),
         'cancelled' => __( "Cancelled", 'directorist' ),

--- a/includes/repositories/order-repository.php
+++ b/includes/repositories/order-repository.php
@@ -11,6 +11,7 @@ use Directorist\Utils\Database\Query\Builder;
 use Directorist\Helpers\DateTime;
 use Directorist\DTO\Order\DTO;
 use Directorist\Enums\Order\Status as OrderStatus;
+use Directorist\Enums\Payment\Status as PaymentStatus;
 use Directorist\Enums\Order\TaxType as OrderTaxType;
 use Directorist\Enums\Order\DiscountType as OrderDiscountType;
 use Directorist\DTO\Order\Read;
@@ -169,7 +170,7 @@ class OrderRepository extends Repository {
 
         do_action( 'directorist_after_order_update', $this->to_dto( $updated_order ), $old_order );
 
-        if ( $dto->is_initialized( 'status' ) ) {
+        if ( $dto->is_initialized( 'status' ) && in_array( $dto->get_status(), PaymentStatus::all(), true ) ) {
             ( new PaymentRepository )->update_status_by_order_id( $dto->get_id(), $dto->get_status() );
         }
 

--- a/includes/rest-api/Version1/class-orders-controller.php
+++ b/includes/rest-api/Version1/class-orders-controller.php
@@ -305,6 +305,7 @@ class Orders_Controller extends Abstract_Controller {
         $map = array(
             'created'   => OrderStatus::PENDING,
             'pending'   => OrderStatus::PENDING,
+            'prepaid'   => OrderStatus::PREPAID,
             'completed' => OrderStatus::PAID,
             'failed'    => OrderStatus::FAILED,
             'cancelled' => OrderStatus::CANCELLED,
@@ -317,6 +318,7 @@ class Orders_Controller extends Abstract_Controller {
     protected function current_status_to_legacy_status( string $status ): string {
         $map = array(
             OrderStatus::PENDING   => 'pending',
+            OrderStatus::PREPAID   => 'prepaid',
             OrderStatus::PAID      => 'completed',
             OrderStatus::FAILED    => 'failed',
             OrderStatus::CANCELLED => 'cancelled',

--- a/includes/setup/activation.php
+++ b/includes/setup/activation.php
@@ -21,6 +21,7 @@ class Activation {
     public static function run() {
         // Run the activation tasks.
         self::create_tables();
+        self::sync_order_status_enum();
     }
 
     public static function create_tables() {
@@ -75,6 +76,27 @@ class Activation {
                 $table->string( "reason" )->nullable();
                 $table->timestamps();
             }
+        );
+    }
+
+    private static function sync_order_status_enum() {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'directorist_orders';
+
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+            return;
+        }
+
+        $statuses = array_map(
+            function( $status ) {
+                return "'" . esc_sql( $status ) . "'";
+            },
+            OrderStatus::all()
+        );
+
+        $wpdb->query(
+            "ALTER TABLE {$table_name} MODIFY status ENUM(" . implode( ',', $statuses ) . ") DEFAULT '" . esc_sql( OrderStatus::PENDING ) . "'"
         );
     }
 }

--- a/includes/setup/activation.php
+++ b/includes/setup/activation.php
@@ -96,7 +96,7 @@ class Activation {
         );
 
         $wpdb->query(
-            "ALTER TABLE {$table_name} MODIFY status ENUM(" . implode( ',', $statuses ) . ") DEFAULT '" . esc_sql( OrderStatus::PENDING ) . "'"
+            "ALTER TABLE {$table_name} MODIFY status ENUM(" . implode( ',', $statuses ) . ") NOT NULL DEFAULT '" . esc_sql( OrderStatus::PENDING ) . "'"
         );
     }
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [x] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Confirm `Directorist\Enums\Order\Status::all()` includes `prepaid`.
2. Run Directorist install/update so the `directorist_orders.status` enum is synced with the new status.
3. Create or update an order to `prepaid` and confirm payment records are not updated to an unsupported payment status.

This PR adds a `prepaid` order status for collected-but-not-yet-renewed payment flows and keeps payment status syncing limited to valid payment statuses.

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
