### PR TITLE
fix: include directory slug in author profile links

### DIFF
--- a/includes/classes/class-permalink.php
+++ b/includes/classes/class-permalink.php
@@ -33,12 +33,26 @@ if ( ! class_exists( 'ATBDP_Permalink' ) ) :
                 $permalink = get_the_permalink( $post_id );
             }
 
+            $directory_slug = self::get_listing_directory_type_slug( $post_id );
+
+            $permalink = str_replace( '%' . ATBDP_DIRECTORY_TYPE . '%', $directory_slug, $permalink );
+
+            return $permalink;
+        }
+
+        /**
+         * Get the directory type slug for a listing.
+         *
+         * @param int $post_id Listing ID.
+         * @return string
+         */
+        public static function get_listing_directory_type_slug( $post_id = 0 ) {
             $directory_slug = '';
             $directory_id   = directorist_get_listing_directory( $post_id );
 
             if ( $directory_id ) {
                 $directory_term = get_term( $directory_id, ATBDP_DIRECTORY_TYPE );
-                $directory_slug = $directory_term ? $directory_term->slug : '';
+                $directory_slug = ( $directory_term && ! is_wp_error( $directory_term ) ) ? $directory_term->slug : '';
             }
 
             if ( empty( $directory_slug ) ) {
@@ -49,9 +63,7 @@ if ( ! class_exists( 'ATBDP_Permalink' ) ) :
                 }
             }
 
-            $permalink = str_replace( '%' . ATBDP_DIRECTORY_TYPE . '%', $directory_slug, $permalink );
-
-            return $permalink;
+            return $directory_slug;
         }
 
         public static function get_listing_slug() {

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -1590,12 +1590,13 @@ class Directorist_Single_Listing {
         $user_pro_pic   = get_user_meta( $this->author_id, 'pro_pic', true );
         $u_pro_pic      = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
         $author_data    = get_userdata( $this->author_id );
+        $directory_type = ATBDP_Permalink::get_listing_directory_type_slug( $this->id );
 
         $author_first_name = ! empty( $author_data ) ?  $author_data->first_name : '';
         $author_last_name  = ! empty( $author_data ) ?  $author_data->last_name : '';
 
         $args = [
-            'author_link'      => ATBDP_Permalink::get_user_profile_page_link( $this->author_id ),
+            'author_link'      => ATBDP_Permalink::get_user_profile_page_link( $this->author_id, $directory_type ),
             'u_pro_pic'        => $u_pro_pic,
             'avatar_img'       => get_avatar( $this->author_id, apply_filters( 'atbdp_avatar_size', 32 ) ),
             'author_full_name' => $author_first_name . ' ' . $author_last_name,

--- a/templates/single/section-author_info.php
+++ b/templates/single/section-author_info.php
@@ -9,12 +9,13 @@ use \Directorist\Helper;
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-$id         = $listing->id;
-$author_id  = $listing->author_id;
-$u_pro_pic  = get_user_meta( $author_id, 'pro_pic', true );
-$u_pro_pic  = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
-$author_img = ! empty( $u_pro_pic ) ? $u_pro_pic[0] : '';
-$avatar_img = get_avatar( $author_id, 32 );
+$id             = $listing->id;
+$author_id      = $listing->author_id;
+$directory_type = ATBDP_Permalink::get_listing_directory_type_slug( $id );
+$u_pro_pic      = get_user_meta( $author_id, 'pro_pic', true );
+$u_pro_pic      = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
+$author_img     = ! empty( $u_pro_pic ) ? $u_pro_pic[0] : '';
+$avatar_img     = get_avatar( $author_id, 32 );
 ?>
 
 <section class="directorist-card directorist-card-author-info <?php echo esc_attr( $class );?>" <?php $listing->section_id( $id ); ?>>
@@ -112,7 +113,7 @@ $avatar_img = get_avatar( $author_id, 32 );
 
             <?php endif; ?>
 
-            <a class="directorist-btn directorist-btn-light directorist-btn-md diretorist-view-profile-btn" href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id ) ); ?>"><?php esc_html_e( 'View Profile', 'directorist' ); ?></a>
+            <a class="directorist-btn directorist-btn-light directorist-btn-md diretorist-view-profile-btn" href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id, $directory_type ) ); ?>"><?php esc_html_e( 'View Profile', 'directorist' ); ?></a>
 
         </div>
     </div>

--- a/templates/widgets/author-info.php
+++ b/templates/widgets/author-info.php
@@ -12,13 +12,14 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     <div class="directorist-single-author-info">
         <?php
-        $listing_id = get_the_ID();
-        $author_id = get_post_field( 'post_author', $listing_id );
-        $author_name = get_the_author_meta( 'display_name', $author_id );
+        $listing_id      = get_the_ID();
+        $author_id       = get_post_field( 'post_author', $listing_id );
+        $directory_type  = ATBDP_Permalink::get_listing_directory_type_slug( $listing_id );
+        $author_name     = get_the_author_meta( 'display_name', $author_id );
         $user_registered = get_the_author_meta( 'user_registered', $author_id );
-        $u_pro_pic = get_user_meta( $author_id, 'pro_pic', true );
-        $u_pro_pic = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
-        $avatar_img = get_avatar( $author_id, apply_filters( 'atbdp_avatar_size', 32 ) );
+        $u_pro_pic       = get_user_meta( $author_id, 'pro_pic', true );
+        $u_pro_pic       = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
+        $avatar_img      = get_avatar( $author_id, apply_filters( 'atbdp_avatar_size', 32 ) );
         ?>
         <div class="directorist-single-author-avatar">
             <figure class="directorist-single-author-avatar-inner">
@@ -124,7 +125,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     <?php endif; ?>
 
-    <a href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id ) ); ?>"
+    <a href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id, $directory_type ) ); ?>"
         class="<?php echo esc_attr( atbdp_directorist_button_classes( 'light' ) ); ?> diretorist-view-profile-btn"><?php esc_html_e( 'View Profile', 'directorist' ); ?>
     </a>
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
The author profile link in the Author Info widget did not include the current listing directory type slug, so multi-directory author profile pages could open without the required directory context.

This PR resolves the listing directory type slug from the current listing and passes it to the author profile permalink generator for both the Author Info widget and the single listing Author Info section.

## How to Test
1. Enable multi-directory and open a single listing for a directory type such as `business`.
2. Click the `View Profile` link in the Author Info widget or single listing Author Info section.
3. Confirm the author profile URL includes the directory type slug, for example `/author-profile/admin/directory/business/`.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)