### PR TITLE
Fix featured listing expiration lifecycle

### DIFF
--- a/includes/classes/class-cron.php
+++ b/includes/classes/class-cron.php
@@ -98,6 +98,10 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
           */
 
         private function featured_listing_followup() {
+            if ( directorist_is_force_disabled_featured_listings() ) {
+                return;
+            }
+
             if ( directorist_is_monetization_enabled() && directorist_is_featured_listing_enabled() ) {
                 $featured_days = get_directorist_option( 'featured_listing_time', 30 );
                 // Define the query

--- a/includes/classes/class-cron.php
+++ b/includes/classes/class-cron.php
@@ -103,7 +103,9 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
             }
 
             if ( directorist_is_monetization_enabled() && directorist_is_featured_listing_enabled() ) {
-                $featured_days = get_directorist_option( 'featured_listing_time', 30 );
+                $featured_days = (int) get_directorist_option( 'featured_listing_time', 30 );
+                $orders        = directorist_order_repository();
+                $current_time  = directorist_now()->getTimestamp();
                 // Define the query
                 $args = [
                     'post_type'      => ATBDP_POST_TYPE,
@@ -124,44 +126,23 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
                 // Start the Loop
                 if ( $listings->found_posts ) {
                     foreach ( $listings->posts as $listing ) {
-                        $order = $this->get_order_by_listing( $listing->ID );
-                        if ( $order ) {
-                            $days = round( abs( strtotime( current_time( 'mysql' ) ) - strtotime( $order[0]->post_date ) ) / 86400 );
-                            if ( $days > $featured_days ) {
-                                do_action( 'atbdp_listing_featured_to_general', $listing->ID );
-                                update_post_meta( $listing->ID, '_featured', '' );
-                            }
+                        $order = $orders->get_latest_paid_featured_order_by_listing_id( $listing->ID );
+
+                        if ( ! $order ) {
+                            continue;
+                        }
+
+                        $expiration = ! empty( $order->expires_at )
+                            ? new \Directorist\Helpers\DateTime( $order->expires_at )
+                            : ( new \Directorist\Helpers\DateTime( $order->created_at ) )->add_days( $featured_days );
+
+                        if ( $expiration->getTimestamp() <= $current_time ) {
+                            do_action( 'atbdp_listing_featured_to_general', $listing->ID );
+                            update_post_meta( $listing->ID, '_featured', '' );
                         }
                     }
                 }
             }
-        }
-
-        private function get_order_by_listing( $listing_id ) {
-            $args = [
-                'post_type'      => ATBDP_ORDER_POST_TYPE,
-                'posts_per_page' => 1,
-                'post_status'    => 'publish',
-                'meta_query'     => [
-                    'relation' => 'AND',
-                    [
-                        'key'   => '_listing_id',
-                        'value' => $listing_id,
-                    ],
-                    [
-                        'key'   => '_payment_status',
-                        'value' => 'completed',
-                    ],
-                ],
-            ];
-
-            $listings = new WP_Query( $args );
-
-            // Start the Loop
-            if ( $listings->found_posts ) {
-                return $listings->posts;
-            }
-            return '';
         }
 
         /**

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -141,7 +141,6 @@ class FeaturedListingCheckout {
 
         if ( empty( $old_order->is_featured_listing )
             || self::CHECKOUT_TYPE !== ( $old_order->ref_type ?? null )
-            || ! empty( $old_order->expires_at )
         ) {
             return;
         }

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -156,13 +156,39 @@ class FeaturedListingCheckout {
 
             // Publish the listing if it's pending
             $listing = get_post( $dto->get_listing_id() );
-            
+
+            if ( $listing ) {
+                $this->updated_listing_expiration( $listing, $dto );
+            }
+
             if ( $listing && 'publish' !== $listing->post_status ) {
                 directorist_set_listing_status( $dto->get_listing_id(), 'publish' );
             }
         } else {
             directorist_set_listing_featured( $dto->get_listing_id(), false );
         }
+    }
+
+    private function updated_listing_expiration( $listing, OrderDTO $order ) {
+        if ( ! $order->is_initialized( 'expires_at' ) || get_post_meta( $listing->ID, '_never_expire', true ) ) {
+            return;
+        }
+
+        $order_expiration        = $order->get_expires_at();
+        $listing_expiration      = get_post_meta( $listing->ID, '_expiry_date', true );
+        $listing_expiration_date = $listing_expiration
+            ? date_create_from_format( 'Y-m-d H:i:s', $listing_expiration, wp_timezone() )
+            : false;
+
+        if (
+            $listing_expiration_date &&
+            $listing_expiration === $listing_expiration_date->format( 'Y-m-d H:i:s' ) &&
+            $listing_expiration_date->getTimestamp() >= $order_expiration->getTimestamp()
+        ) {
+            return;
+        }
+
+        update_post_meta( $listing->ID, '_expiry_date', $order_expiration->format( 'Y-m-d H:i:s' ) );
     }
 
     public function handle_payment_receipt_order_items( array $order_items, OrderDTO $order ) {

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -31,7 +31,6 @@ class FeaturedListingCheckout {
         add_action( 'directorist_checkout_table', [$this, 'handle_checkout_table'], 10, 4 );
         add_filter( 'directorist_checkout_subtotal', [$this, 'handle_checkout_subtotal'], 10, 3 );
         add_action( 'directorist_checkout_create_order', [$this, 'handle_checkout_create_order'], 10, 3 );
-        add_action( 'directorist_before_order_update', [$this, 'handle_before_order_update'], 10, 2 );
         add_filter( 'directorist_checkout_product_name', [$this, 'handle_checkout_product_name'], 10, 2 );
         add_filter( 'directorist_ajax_listing_submission_response', [ $this, 'handle_listing_submission_response_data' ], 10, 2 );
         add_filter( 'directorist_listing_update_args_after_preview', [ $this, 'handle_listing_status_after_preview' ], 10, 2 );
@@ -134,21 +133,6 @@ class FeaturedListingCheckout {
         $dto->set_listing_id( $request->get_param( 'listing_id' ) )->set_is_featured_listing( 1 )->set_ref_type( self::CHECKOUT_TYPE )->set_amount( $amount )->set_sub_total( $amount );
     }
 
-    public function handle_before_order_update( OrderDTO $dto, $old_order ) {
-        if ( ! $dto->is_initialized( 'status' ) || $dto->get_status() !== Status::PAID ) {
-            return;
-        }
-
-        if ( empty( $old_order->is_featured_listing )
-            || self::CHECKOUT_TYPE !== ( $old_order->ref_type ?? null )
-        ) {
-            return;
-        }
-
-        $featured_days = (int) get_directorist_option( 'featured_listing_time', 30 );
-        $dto->set_expires_at( directorist_now()->add_days( $featured_days ) );
-    }
-
     public function handle_after_order_update( OrderDTO $dto ) {
         if ( ! $this->is_featured_order( $dto ) ) {
             return;
@@ -177,11 +161,13 @@ class FeaturedListingCheckout {
     }
 
     private function updated_listing_expiration( $listing, OrderDTO $order ) {
-        if ( ! $order->is_initialized( 'expires_at' ) || get_post_meta( $listing->ID, '_never_expire', true ) ) {
+        if ( get_post_meta( $listing->ID, '_never_expire', true ) ) {
             return;
         }
 
-        $order_expiration        = $order->get_expires_at();
+        $featured_days    = (int) get_directorist_option( 'featured_listing_time', 30 );
+        $order_expiration = directorist_now()->add_days( $featured_days );
+
         $listing_expiration      = get_post_meta( $listing->ID, '_expiry_date', true );
         $listing_expiration_date = $listing_expiration
             ? date_create_from_format( 'Y-m-d H:i:s', $listing_expiration, wp_timezone() )
@@ -193,6 +179,9 @@ class FeaturedListingCheckout {
         ) {
             return;
         }
+
+        $order->set_expires_at( $order_expiration );
+        directorist_order_repository()->silent_update( $order );
 
         update_post_meta( $listing->ID, '_expiry_date', $order_expiration->format( 'Y-m-d H:i:s' ) );
     }

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -14,10 +14,15 @@ class FeaturedListingCheckout {
     const CHECKOUT_TYPE = 'featured_listing';
 
     public function __construct()  {
-        add_filter( 'directorist_checkout_types', [$this, 'add_checkout_type'] );
         add_filter( 'directorist_order_data', [ $this, 'handle_order_data' ] );
-        add_action( 'directorist_after_order_update', [$this, 'handle_after_order_update'] );
         add_filter( 'directorist_payment_receipt_order_items', [$this, 'handle_payment_receipt_order_items'], 10, 2 );
+
+        if ( directorist_is_force_disabled_featured_listings() ) {
+            return;
+        }
+
+        add_filter( 'directorist_checkout_types', [$this, 'add_checkout_type'] );
+        add_action( 'directorist_after_order_update', [$this, 'handle_after_order_update'] );
         add_filter( 'directorist_checkout_validation', [$this, 'validate_checkout'], 10, 2 );
         add_action( 'directorist_checkout_table', [$this, 'handle_checkout_table'], 10, 4 );
         add_filter( 'directorist_checkout_subtotal', [$this, 'handle_checkout_subtotal'], 10, 3 );

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -31,7 +31,7 @@ class FeaturedListingCheckout {
         add_action( 'directorist_checkout_table', [$this, 'handle_checkout_table'], 10, 4 );
         add_filter( 'directorist_checkout_subtotal', [$this, 'handle_checkout_subtotal'], 10, 3 );
         add_action( 'directorist_checkout_create_order', [$this, 'handle_checkout_create_order'], 10, 3 );
-        add_action( 'directorist_before_order_update', [$this, 'handle_before_order_update'] );
+        add_action( 'directorist_before_order_update', [$this, 'handle_before_order_update'], 10, 2 );
         add_filter( 'directorist_checkout_product_name', [$this, 'handle_checkout_product_name'], 10, 2 );
         add_filter( 'directorist_ajax_listing_submission_response', [ $this, 'handle_listing_submission_response_data' ], 10, 2 );
         add_filter( 'directorist_listing_update_args_after_preview', [ $this, 'handle_listing_status_after_preview' ], 10, 2 );
@@ -134,21 +134,20 @@ class FeaturedListingCheckout {
         $dto->set_listing_id( $request->get_param( 'listing_id' ) )->set_is_featured_listing( 1 )->set_ref_type( self::CHECKOUT_TYPE )->set_amount( $amount )->set_sub_total( $amount );
     }
 
-    public function handle_before_order_update( OrderDTO $dto ) {
-        if ( ! $this->is_featured_order( $dto ) ) {
-            return;
-        }
-
+    public function handle_before_order_update( OrderDTO $dto, $old_order ) {
         if ( ! $dto->is_initialized( 'status' ) || $dto->get_status() !== Status::PAID ) {
             return;
         }
 
-        $order = directorist_get_order_by_id( $dto->get_id() );
-
-        if ( $order->is_featured_listing && ! $order->expires_at ) {
-            $featured_days = get_directorist_option( 'featured_listing_time', 30 );
-            $dto->set_expires_at( directorist_now()->add_days( $featured_days ) );
+        if ( empty( $old_order->is_featured_listing )
+            || self::CHECKOUT_TYPE !== ( $old_order->ref_type ?? null )
+            || ! empty( $old_order->expires_at )
+        ) {
+            return;
         }
+
+        $featured_days = (int) get_directorist_option( 'featured_listing_time', 30 );
+        $dto->set_expires_at( directorist_now()->add_days( $featured_days ) );
     }
 
     public function handle_after_order_update( OrderDTO $dto ) {

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -13,10 +13,14 @@ use Directorist\Utils\Template;
 class FeaturedListingCheckout {
     const CHECKOUT_TYPE = 'featured_listing';
 
-    public function __construct()  {
+    public function __construct() {
         add_filter( 'directorist_order_data', [ $this, 'handle_order_data' ] );
         add_filter( 'directorist_payment_receipt_order_items', [$this, 'handle_payment_receipt_order_items'], 10, 2 );
 
+        add_action( 'plugins_loaded', [ $this, 'register_hooks' ], 20 );
+    }
+
+    public function register_hooks() {
         if ( directorist_is_force_disabled_featured_listings() ) {
             return;
         }
@@ -185,10 +189,9 @@ class FeaturedListingCheckout {
             ? date_create_from_format( 'Y-m-d H:i:s', $listing_expiration, wp_timezone() )
             : false;
 
-        if (
-            $listing_expiration_date &&
-            $listing_expiration === $listing_expiration_date->format( 'Y-m-d H:i:s' ) &&
-            $listing_expiration_date->getTimestamp() >= $order_expiration->getTimestamp()
+        if ( $listing_expiration_date
+            && $listing_expiration === $listing_expiration_date->format( 'Y-m-d H:i:s' )
+            && $listing_expiration_date->getTimestamp() >= $order_expiration->getTimestamp()
         ) {
             return;
         }
@@ -237,7 +240,7 @@ class FeaturedListingCheckout {
     }
 
     public function is_featured_order( OrderDTO $order_dto ): bool {
-        if ( ! $order_dto->is_initialized( 'ref_type' ) || ! $order_dto->is_initialized( 'ref' ) || ! $order_dto->is_initialized( 'listing_id' ) ) {
+        if ( ! $order_dto->is_initialized( 'ref_type' ) || ! $order_dto->is_initialized( 'listing_id' ) ) {
             return false;
         }
         

--- a/includes/directorist-core-functions.php
+++ b/includes/directorist-core-functions.php
@@ -18,6 +18,13 @@ function directorist_is_guest_submission_enabled() {
     return (bool) get_directorist_option( 'guest_listings', false );
 }
 
+/**
+ * @return bool
+ */
+function directorist_is_force_disabled_featured_listings() {
+    return (bool) apply_filters( 'directorist_is_force_disabled_featured_listings', false );
+}
+
 function directorist_is_featured_listing_enabled( array $context = [] ) {
     return (bool) apply_filters( 'directorist_is_featured_listing_enabled', get_directorist_option( 'enable_featured_listing' ), $context );
 }

--- a/includes/repositories/order-repository.php
+++ b/includes/repositories/order-repository.php
@@ -94,6 +94,7 @@ class OrderRepository extends Repository {
             ->select( 'd_order.created_at', 'd_order.expires_at' )
             ->where( 'd_order.listing_id', $listing_id )
             ->where( 'd_order.is_featured_listing', 1 )
+            ->where( 'd_order.ref_type', 'featured_listing' )
             ->where( 'd_order.status', OrderStatus::PAID )
             ->order_by_desc( 'd_order.id' )
             ->first();

--- a/includes/repositories/order-repository.php
+++ b/includes/repositories/order-repository.php
@@ -89,6 +89,16 @@ class OrderRepository extends Repository {
         return $order ? true : false;
     }
 
+    public function get_latest_paid_featured_order_by_listing_id( int $listing_id ) {
+        return $this->get_query_builder()
+            ->select( 'd_order.created_at', 'd_order.expires_at' )
+            ->where( 'd_order.listing_id', $listing_id )
+            ->where( 'd_order.is_featured_listing', 1 )
+            ->where( 'd_order.status', OrderStatus::PAID )
+            ->order_by_desc( 'd_order.id' )
+            ->first();
+    }
+
     protected function get_orders( Builder $query, Read $dto ) {
         $query = apply_filters( 'directorist_order_list_query', $query, $dto );
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

### Why is this PR needed?

Featured listing expiration was not synchronized with the paid featured order expiration. The expiration cron also relied on the legacy order post type and post meta instead of the new order table. Core featured listing handling additionally needs to be disableable when another provider owns the feature lifecycle.

### What is done in this PR?

- Synchronize a listing expiration with the paid featured order expiration while preserving later expiration dates and never-expire listings.
- Add a filtered force-disable guard to the core featured checkout and expiration cron.
- Query the latest paid featured order from the new directorist_orders table through the order repository.
- Use the persisted order expiration, with a created date plus configured duration fallback for migrated orders without an expiration value.
- Remove the legacy order post and post-meta lookup from the featured expiration cron.

### How to test

1. Enable monetization and featured listings, then configure a featured listing duration.
2. Submit or upgrade a listing as featured and complete its order so the order status becomes paid.
3. Verify the listing is featured and its expiration is not earlier than the paid order expiration.
4. Set the latest paid featured order expiration to a past date and run the Directorist scheduled task.
5. Verify the cron removes featured status from the listing.
6. Add a filter that makes directorist_is_force_disabled_featured_listings return true and run the scheduled task again.
7. Verify core checkout handling is unavailable and the cron does not remove featured status.

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)