### PR TITLE
fix: preserve taxonomy subterm depth per root

### DIFF
--- a/includes/model/ListingTaxonomy.php
+++ b/includes/model/ListingTaxonomy.php
@@ -184,10 +184,12 @@ class Directorist_Listing_Taxonomy {
         return $html;
     }
 
-    public function subterms_html( $term ) {
+    public function subterms_html( $term, $depth = null ) {
 
-        if ( $this->depth <= 0 ) {
-            return;
+        $depth = is_null( $depth ) ? $this->depth : $depth;
+
+        if ( $depth <= 0 ) {
+            return '';
         }
 
         $args = [
@@ -204,7 +206,7 @@ class Directorist_Listing_Taxonomy {
 
         if ( count( $terms ) > 0 ) {
 
-            --$this->depth;
+            --$depth;
 
             $html .= '<ul class="directorist-taxonomy-list__sub-item">';
 
@@ -234,7 +236,7 @@ class Directorist_Listing_Taxonomy {
                     $html .= ' (' . $count . ')' . $plus_icon;
                 }
                 $html .= "</a>";
-                $html .= $this->subterms_html( $term );
+                $html .= $this->subterms_html( $term, $depth );
                 $html .= '</li>';
             }
 

--- a/tests/php/listing-taxonomy-subterms.php
+++ b/tests/php/listing-taxonomy-subterms.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Regression test for taxonomy list subterm depth handling.
+ *
+ * Run with: php tests/php/listing-taxonomy-subterms.php
+ *
+ * @package Directorist
+ */
+
+define( 'ABSPATH', dirname( __DIR__, 2 ) . '/' );
+define( 'ATBDP_LOCATION', 'at_biz_dir-location' );
+
+/**
+ * Minimal permalink stub used by the taxonomy model.
+ */
+class ATBDP_Permalink {
+    /**
+     * Return a location permalink.
+     *
+     * @param object $term           Location term.
+     * @param string $directory_type Directory type.
+     * @return string
+     */
+    public static function atbdp_get_location_page( $term, $directory_type = '' ) {
+        unset( $directory_type );
+
+        return '/location/' . $term->term_id;
+    }
+
+    /**
+     * Return a category permalink.
+     *
+     * @param object $term           Category term.
+     * @param string $directory_type Directory type.
+     * @return string
+     */
+    public static function atbdp_get_category_page( $term, $directory_type = '' ) {
+        unset( $directory_type );
+
+        return '/category/' . $term->term_id;
+    }
+}
+
+/**
+ * Stores the taxonomy fixtures used by the WordPress function stubs.
+ */
+class Directorist_Taxonomy_Test_Data {
+    /**
+     * Child terms keyed by parent ID.
+     *
+     * @var array
+     */
+    public static $children = [];
+}
+
+/**
+ * Minimal get_terms() stub.
+ *
+ * @param array $args Query arguments.
+ * @return array
+ */
+function get_terms( $args ) {
+    return isset( Directorist_Taxonomy_Test_Data::$children[ $args['parent'] ] )
+        ? Directorist_Taxonomy_Test_Data::$children[ $args['parent'] ]
+        : [];
+}
+
+/**
+ * Minimal get_term_children() stub.
+ *
+ * @param int    $term_id  Parent term ID.
+ * @param string $taxonomy Taxonomy name.
+ * @return array
+ */
+function get_term_children( $term_id, $taxonomy ) {
+    unset( $taxonomy );
+
+    if ( empty( Directorist_Taxonomy_Test_Data::$children[ $term_id ] ) ) {
+        return [];
+    }
+
+    return array_map(
+        function( $term ) {
+            return $term->term_id;
+        },
+        Directorist_Taxonomy_Test_Data::$children[ $term_id ]
+    );
+}
+
+require ABSPATH . 'includes/model/ListingTaxonomy.php';
+
+/**
+ * Create a term fixture.
+ *
+ * @param int    $term_id Term ID.
+ * @param string $name    Term name.
+ * @return object
+ */
+function directorist_test_term( $term_id, $name ) {
+    return (object) [
+        'term_id' => $term_id,
+        'name'    => $name,
+    ];
+}
+
+/**
+ * Create a taxonomy model without loading WordPress.
+ *
+ * @param int $depth Maximum subterm depth.
+ * @return Directorist\Directorist_Listing_Taxonomy
+ */
+function directorist_test_taxonomy( $depth ) {
+    $reflection = new ReflectionClass( 'Directorist\\Directorist_Listing_Taxonomy' );
+    $taxonomy   = $reflection->newInstanceWithoutConstructor();
+
+    $taxonomy->depth                = $depth;
+    $taxonomy->tax                  = ATBDP_LOCATION;
+    $taxonomy->orderby              = 'id';
+    $taxonomy->order                = 'asc';
+    $taxonomy->hide_empty           = false;
+    $taxonomy->show_count           = false;
+    $taxonomy->type                 = 'location';
+    $taxonomy->directory_type       = [];
+    $taxonomy->directory_type_count = 0;
+
+    return $taxonomy;
+}
+
+/**
+ * Stop the test when an assertion fails.
+ *
+ * @param bool   $condition Assertion result.
+ * @param string $message   Failure message.
+ * @return void
+ */
+function directorist_test_assert( $condition, $message ) {
+    if ( $condition ) {
+        return;
+    }
+
+    fwrite( STDERR, "FAIL: {$message}\n" );
+    exit( 1 );
+}
+
+Directorist_Taxonomy_Test_Data::$children = [
+    1 => [ directorist_test_term( 101, 'USA child' ) ],
+    2 => [ directorist_test_term( 201, 'South Africa child' ) ],
+    3 => [ directorist_test_term( 301, 'Australia child' ) ],
+    4 => [ directorist_test_term( 401, 'Africa child' ) ],
+];
+
+$taxonomy = directorist_test_taxonomy( 2 );
+$roots    = [
+    directorist_test_term( 1, 'USA' ),
+    directorist_test_term( 2, 'South Africa' ),
+    directorist_test_term( 3, 'Australia' ),
+    directorist_test_term( 4, 'Africa' ),
+];
+
+foreach ( $roots as $root ) {
+    $html = $taxonomy->subterms_html( $root );
+
+    directorist_test_assert(
+        false !== strpos( $html, $root->name . ' child' ),
+        "{$root->name} should render its child list."
+    );
+}
+
+directorist_test_assert( 2 === $taxonomy->depth, 'Rendering one root must not reduce the depth available to another root.' );
+
+Directorist_Taxonomy_Test_Data::$children = [
+    10 => [ directorist_test_term( 11, 'Level 1' ) ],
+    11 => [ directorist_test_term( 12, 'Level 2' ) ],
+    12 => [ directorist_test_term( 13, 'Level 3' ) ],
+];
+
+$taxonomy = directorist_test_taxonomy( 2 );
+$html     = $taxonomy->subterms_html( directorist_test_term( 10, 'Root' ) );
+
+directorist_test_assert( false !== strpos( $html, 'Level 1' ), 'The first configured subterm level should render.' );
+directorist_test_assert( false !== strpos( $html, 'Level 2' ), 'The second configured subterm level should render.' );
+directorist_test_assert( false === strpos( $html, 'Level 3' ), 'Terms deeper than the configured depth should not render.' );
+
+echo "PASS: taxonomy subterm depth is isolated per root.\n";


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
### Main issue
The All Locations and All Categories list views used one shared `$this->depth` value while rendering every top-level taxonomy term. `subterms_html()` reduced that property during recursion and never restored it.

As a result, earlier roots consumed the configured depth. Later roots could still have `has_child = true`, so the template displayed a dropdown arrow, but their `subterm_html` was empty. Clicking those dropdowns only toggled a CSS class because no child `<ul>` had been rendered.

The reported location order reproduced the problem clearly with depth `2`:

1. USA rendered its children and reduced the shared depth to `1`.
2. South Africa rendered its children and reduced the shared depth to `0`.
3. Australia and Africa still had children but rendered no child list.

### Fix
The remaining depth is now passed by value to each recursive call. The configured `$this->depth` property is left unchanged, so every top-level root gets the same depth budget while deeper terms still respect the configured limit.

A dependency-free regression test was added because this repository does not currently include a PHPUnit test suite.

### How to reproduce and test
1. Create four top-level locations in this order: USA, South Africa, Australia, and Africa.
2. Add at least one child under every top-level location and set the location depth to `2`.
3. Before this change, only the earlier roots render dropdown content; Australia and Africa show arrows but do not open.
4. Run `php tests/php/listing-taxonomy-subterms.php`.
5. Confirm the command prints `PASS: taxonomy subterm depth is isolated per root.`
6. Confirm every top-level location renders its child list and terms deeper than the configured depth remain hidden.

## Any linked issues
- TeamSync issue: https://team.sovware.com/support/directorist/3243
- Help Scout conversation: https://secure.helpscout.net/conversation/3419291291/6143

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)