### PR TITLE
Fix optional dropdown auto-selecting the first value

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,7 +1,7 @@
 <?php
 // Plugin version.
 if ( ! defined( 'ATBDP_VERSION' ) ) {
-    define( 'ATBDP_VERSION', '8.9.3' );
+    define( 'ATBDP_VERSION', '8.9.4' );
 }
 // Plugin Folder Path.
 if ( ! defined( 'ATBDP_DIR' ) ) {

--- a/directorist-base.php
+++ b/directorist-base.php
@@ -3,7 +3,7 @@
  * Plugin Name: Directorist - Business Directory Solution
  * Plugin URI: https://wpwax.com
  * Description: A comprehensive solution to create professional looking directory site of any kind. Like Yelp, Foursquare, etc.
- * Version: 8.9.3
+ * Version: 8.9.4
  * Requires PHP: 7.4
  * Author: wpWax
  * Author URI: https://wpwax.com

--- a/includes/classes/class-permalink.php
+++ b/includes/classes/class-permalink.php
@@ -33,12 +33,26 @@ if ( ! class_exists( 'ATBDP_Permalink' ) ) :
                 $permalink = get_the_permalink( $post_id );
             }
 
+            $directory_slug = self::get_listing_directory_type_slug( $post_id );
+
+            $permalink = str_replace( '%' . ATBDP_DIRECTORY_TYPE . '%', $directory_slug, $permalink );
+
+            return $permalink;
+        }
+
+        /**
+         * Get the directory type slug for a listing.
+         *
+         * @param int $post_id Listing ID.
+         * @return string
+         */
+        public static function get_listing_directory_type_slug( $post_id = 0 ) {
             $directory_slug = '';
             $directory_id   = directorist_get_listing_directory( $post_id );
 
             if ( $directory_id ) {
                 $directory_term = get_term( $directory_id, ATBDP_DIRECTORY_TYPE );
-                $directory_slug = $directory_term ? $directory_term->slug : '';
+                $directory_slug = ( $directory_term && ! is_wp_error( $directory_term ) ) ? $directory_term->slug : '';
             }
 
             if ( empty( $directory_slug ) ) {
@@ -49,9 +63,7 @@ if ( ! class_exists( 'ATBDP_Permalink' ) ) :
                 }
             }
 
-            $permalink = str_replace( '%' . ATBDP_DIRECTORY_TYPE . '%', $directory_slug, $permalink );
-
-            return $permalink;
+            return $directory_slug;
         }
 
         public static function get_listing_slug() {

--- a/includes/enums/order/status.php
+++ b/includes/enums/order/status.php
@@ -6,6 +6,7 @@ defined( "ABSPATH" ) || exit;
 
 class Status {
     const PENDING   = 'pending';
+    const PREPAID   = 'prepaid';
     const PAID      = 'paid';
     const FAILED    = 'failed';
     const CANCELLED = 'cancelled';
@@ -16,6 +17,7 @@ class Status {
     public static function all() {
         return [
             self::PENDING,
+            self::PREPAID,
             self::PAID,
             self::FAILED,
             self::CANCELLED,

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -1590,12 +1590,13 @@ class Directorist_Single_Listing {
         $user_pro_pic   = get_user_meta( $this->author_id, 'pro_pic', true );
         $u_pro_pic      = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
         $author_data    = get_userdata( $this->author_id );
+        $directory_type = ATBDP_Permalink::get_listing_directory_type_slug( $this->id );
 
         $author_first_name = ! empty( $author_data ) ?  $author_data->first_name : '';
         $author_last_name  = ! empty( $author_data ) ?  $author_data->last_name : '';
 
         $args = [
-            'author_link'      => ATBDP_Permalink::get_user_profile_page_link( $this->author_id ),
+            'author_link'      => ATBDP_Permalink::get_user_profile_page_link( $this->author_id, $directory_type ),
             'u_pro_pic'        => $u_pro_pic,
             'avatar_img'       => get_avatar( $this->author_id, apply_filters( 'atbdp_avatar_size', 32 ) ),
             'author_full_name' => $author_first_name . ' ' . $author_last_name,

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -45,6 +45,7 @@ function atbdp_get_payment_statuses() {
     $statuses = [
         'created' => __( "Created", 'directorist' ),
         'pending' => __( "Pending", 'directorist' ),
+        'prepaid' => __( "Prepaid", 'directorist' ),
         'completed' => __( "Completed", 'directorist' ),
         'failed' => __( "Failed", 'directorist' ),
         'cancelled' => __( "Cancelled", 'directorist' ),

--- a/includes/repositories/order-repository.php
+++ b/includes/repositories/order-repository.php
@@ -11,6 +11,7 @@ use Directorist\Utils\Database\Query\Builder;
 use Directorist\Helpers\DateTime;
 use Directorist\DTO\Order\DTO;
 use Directorist\Enums\Order\Status as OrderStatus;
+use Directorist\Enums\Payment\Status as PaymentStatus;
 use Directorist\Enums\Order\TaxType as OrderTaxType;
 use Directorist\Enums\Order\DiscountType as OrderDiscountType;
 use Directorist\DTO\Order\Read;
@@ -169,7 +170,7 @@ class OrderRepository extends Repository {
 
         do_action( 'directorist_after_order_update', $this->to_dto( $updated_order ), $old_order );
 
-        if ( $dto->is_initialized( 'status' ) ) {
+        if ( $dto->is_initialized( 'status' ) && in_array( $dto->get_status(), PaymentStatus::all(), true ) ) {
             ( new PaymentRepository )->update_status_by_order_id( $dto->get_id(), $dto->get_status() );
         }
 

--- a/includes/rest-api/Version1/class-orders-controller.php
+++ b/includes/rest-api/Version1/class-orders-controller.php
@@ -305,6 +305,7 @@ class Orders_Controller extends Abstract_Controller {
         $map = array(
             'created'   => OrderStatus::PENDING,
             'pending'   => OrderStatus::PENDING,
+            'prepaid'   => OrderStatus::PREPAID,
             'completed' => OrderStatus::PAID,
             'failed'    => OrderStatus::FAILED,
             'cancelled' => OrderStatus::CANCELLED,
@@ -317,6 +318,7 @@ class Orders_Controller extends Abstract_Controller {
     protected function current_status_to_legacy_status( string $status ): string {
         $map = array(
             OrderStatus::PENDING   => 'pending',
+            OrderStatus::PREPAID   => 'prepaid',
             OrderStatus::PAID      => 'completed',
             OrderStatus::FAILED    => 'failed',
             OrderStatus::CANCELLED => 'cancelled',

--- a/includes/setup/activation.php
+++ b/includes/setup/activation.php
@@ -21,6 +21,7 @@ class Activation {
     public static function run() {
         // Run the activation tasks.
         self::create_tables();
+        self::sync_order_status_enum();
     }
 
     public static function create_tables() {
@@ -75,6 +76,27 @@ class Activation {
                 $table->string( "reason" )->nullable();
                 $table->timestamps();
             }
+        );
+    }
+
+    private static function sync_order_status_enum() {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'directorist_orders';
+
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) !== $table_name ) {
+            return;
+        }
+
+        $statuses = array_map(
+            function( $status ) {
+                return "'" . esc_sql( $status ) . "'";
+            },
+            OrderStatus::all()
+        );
+
+        $wpdb->query(
+            "ALTER TABLE {$table_name} MODIFY status ENUM(" . implode( ',', $statuses ) . ") DEFAULT '" . esc_sql( OrderStatus::PENDING ) . "'"
         );
     }
 }

--- a/includes/setup/activation.php
+++ b/includes/setup/activation.php
@@ -96,7 +96,7 @@ class Activation {
         );
 
         $wpdb->query(
-            "ALTER TABLE {$table_name} MODIFY status ENUM(" . implode( ',', $statuses ) . ") DEFAULT '" . esc_sql( OrderStatus::PENDING ) . "'"
+            "ALTER TABLE {$table_name} MODIFY status ENUM(" . implode( ',', $statuses ) . ") NOT NULL DEFAULT '" . esc_sql( OrderStatus::PENDING ) . "'"
         );
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: business directory, listings, classifieds, directory plugin, directory
 Requires at least: 4.6
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 8.9.3
+Stable tag: 8.9.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -299,6 +299,14 @@ Directorist is developer-friendly with plenty of hooks and filters. You can exte
 Directorist comes with an AI-powered directory builder. Use the Create with AI option, provide directory name, location and AI will build the directory for you.
 
 == Changelog ==
+
+= 8.9.4 - Aug 18, 2026 =
+
+**Improved**
+- Added prepaid order status support across order management and REST API status mapping. (#2955)
+
+**Fixed**
+- Author profile links missing directory type slug in multi-directory listings. (#2957)
 
 = 8.9.3 - Aug 9, 2026 =
 

--- a/templates/listing-form/custom-fields/select.php
+++ b/templates/listing-form/custom-fields/select.php
@@ -2,24 +2,34 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 8.6
+ * @version 8.9.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 // Get conditional logic attributes using centralized method
 $conditional_logic_attr = $listing_form->get_conditional_logic_attributes( $data );
+$options                = ! empty( $data['options'] ) && is_array( $data['options'] ) ? $data['options'] : [];
+$has_empty_option       = in_array( '', wp_list_pluck( $options, 'option_value' ), true );
+$show_empty_option      = empty( $data['required'] ) && ! $has_empty_option;
+$placeholder            = ! empty( $data['placeholder'] ) ? $data['placeholder'] : __( 'Select...', 'directorist' );
 ?>
 
 <div class="directorist-form-group directorist-custom-field-select"<?php echo $conditional_logic_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped in get_conditional_logic_attributes() ?>>
 
     <?php $listing_form->field_label_template( $data );?>
 
-    <?php if ( ! empty( $data['options'] ) ) : ?>
+    <?php if ( ! empty( $options ) ) : ?>
 
         <select name="<?php echo esc_attr( $data['field_key'] ); ?>" id="<?php echo esc_attr( $data['field_key'] ); ?>" class="directorist-form-element" <?php $listing_form->required( $data ); ?>>
 
-            <?php foreach ( $data['options'] as $key => $value ) : ?>
+            <?php if ( $show_empty_option ) : ?>
+
+                <option value="" <?php selected( '', $data['value'] ); ?>><?php echo esc_html( $placeholder ); ?></option>
+
+            <?php endif; ?>
+
+            <?php foreach ( $options as $value ) : ?>
 
                 <option value="<?php echo esc_attr( $value['option_value'] )?>" <?php selected( $value['option_value'], $data['value'] ); ?>><?php echo esc_attr( $value['option_label'] )?></option>
 

--- a/templates/single/section-author_info.php
+++ b/templates/single/section-author_info.php
@@ -9,12 +9,13 @@ use \Directorist\Helper;
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-$id         = $listing->id;
-$author_id  = $listing->author_id;
-$u_pro_pic  = get_user_meta( $author_id, 'pro_pic', true );
-$u_pro_pic  = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
-$author_img = ! empty( $u_pro_pic ) ? $u_pro_pic[0] : '';
-$avatar_img = get_avatar( $author_id, 32 );
+$id             = $listing->id;
+$author_id      = $listing->author_id;
+$directory_type = ATBDP_Permalink::get_listing_directory_type_slug( $id );
+$u_pro_pic      = get_user_meta( $author_id, 'pro_pic', true );
+$u_pro_pic      = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
+$author_img     = ! empty( $u_pro_pic ) ? $u_pro_pic[0] : '';
+$avatar_img     = get_avatar( $author_id, 32 );
 ?>
 
 <section class="directorist-card directorist-card-author-info <?php echo esc_attr( $class );?>" <?php $listing->section_id( $id ); ?>>
@@ -112,7 +113,7 @@ $avatar_img = get_avatar( $author_id, 32 );
 
             <?php endif; ?>
 
-            <a class="directorist-btn directorist-btn-light directorist-btn-md diretorist-view-profile-btn" href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id ) ); ?>"><?php esc_html_e( 'View Profile', 'directorist' ); ?></a>
+            <a class="directorist-btn directorist-btn-light directorist-btn-md diretorist-view-profile-btn" href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id, $directory_type ) ); ?>"><?php esc_html_e( 'View Profile', 'directorist' ); ?></a>
 
         </div>
     </div>

--- a/templates/widgets/author-info.php
+++ b/templates/widgets/author-info.php
@@ -12,13 +12,14 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     <div class="directorist-single-author-info">
         <?php
-        $listing_id = get_the_ID();
-        $author_id = get_post_field( 'post_author', $listing_id );
-        $author_name = get_the_author_meta( 'display_name', $author_id );
+        $listing_id      = get_the_ID();
+        $author_id       = get_post_field( 'post_author', $listing_id );
+        $directory_type  = ATBDP_Permalink::get_listing_directory_type_slug( $listing_id );
+        $author_name     = get_the_author_meta( 'display_name', $author_id );
         $user_registered = get_the_author_meta( 'user_registered', $author_id );
-        $u_pro_pic = get_user_meta( $author_id, 'pro_pic', true );
-        $u_pro_pic = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
-        $avatar_img = get_avatar( $author_id, apply_filters( 'atbdp_avatar_size', 32 ) );
+        $u_pro_pic       = get_user_meta( $author_id, 'pro_pic', true );
+        $u_pro_pic       = ! empty( $u_pro_pic ) ? wp_get_attachment_image_src( $u_pro_pic, 'thumbnail' ) : '';
+        $avatar_img      = get_avatar( $author_id, apply_filters( 'atbdp_avatar_size', 32 ) );
         ?>
         <div class="directorist-single-author-avatar">
             <figure class="directorist-single-author-avatar-inner">
@@ -124,7 +125,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     <?php endif; ?>
 
-    <a href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id ) ); ?>"
+    <a href="<?php echo esc_url( ATBDP_Permalink::get_user_profile_page_link( $author_id, $directory_type ) ); ?>"
         class="<?php echo esc_attr( atbdp_directorist_button_classes( 'light' ) ); ?> diretorist-view-profile-btn"><?php esc_html_e( 'View Profile', 'directorist' ); ?>
     </a>
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

### Main issue

An optional custom Dropdown rendered only its configured choices. When a new listing or an imported listing had no saved value for that field, the browser automatically selected the first choice because the `<select>` had no empty option. Saving the form could then store that first choice even though the user never selected it.

The CSV importer itself does not assign the first choice for an empty cell; the unintended value came from the dropdown's rendered default state when the listing was later edited and saved.

### Solution

- Add an empty `Select...` option to optional custom Dropdown fields.
- Use the configured field placeholder when one exists.
- Preserve the selected state for listings that already have a saved value.
- Avoid adding a second empty option when the field already defines one.
- Keep required Dropdown behavior unchanged.

### Easy test cases

1. Add an optional custom Dropdown with `New` and `Used` choices, then open the Add Listing form. Confirm `Select...` is selected by default.
2. Save the listing without choosing a value. Confirm the field remains empty and is not shown as `New` on the listing.
3. Select `Used`, save, and reopen the listing. Confirm `Used` remains selected.
4. Import a listing with the Dropdown CSV cell empty, then edit and save it without choosing a value. Confirm the field remains empty.
5. Make the Dropdown required. Confirm its existing behavior is unchanged and no empty option is added.
6. Configure an empty option manually. Confirm only one empty option appears.

### Verification performed

- PHP syntax check
- PHPCS on the changed template
- PHP 8.1+ compatibility check on the changed template
- Runtime rendering checks for empty, saved, required, existing-empty, and custom-placeholder cases
- Runtime submission check confirming an empty optional value is removed from listing metadata

## Any linked issues

- TeamSync issue #3246: https://team.sovware.com/support/directorist/3246
- Help Scout conversation #6226: https://secure.helpscout.net/conversation/3422925278/6226?viewId=8936453

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
