### PR TITLE
Fix optional dropdown auto-selecting the first value

### DIFF
--- a/templates/listing-form/custom-fields/select.php
+++ b/templates/listing-form/custom-fields/select.php
@@ -2,24 +2,34 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 8.6
+ * @version 8.9.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 // Get conditional logic attributes using centralized method
 $conditional_logic_attr = $listing_form->get_conditional_logic_attributes( $data );
+$options                = ! empty( $data['options'] ) && is_array( $data['options'] ) ? $data['options'] : [];
+$has_empty_option       = in_array( '', wp_list_pluck( $options, 'option_value' ), true );
+$show_empty_option      = empty( $data['required'] ) && ! $has_empty_option;
+$placeholder            = ! empty( $data['placeholder'] ) ? $data['placeholder'] : __( 'Select...', 'directorist' );
 ?>
 
 <div class="directorist-form-group directorist-custom-field-select"<?php echo $conditional_logic_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped in get_conditional_logic_attributes() ?>>
 
     <?php $listing_form->field_label_template( $data );?>
 
-    <?php if ( ! empty( $data['options'] ) ) : ?>
+    <?php if ( ! empty( $options ) ) : ?>
 
         <select name="<?php echo esc_attr( $data['field_key'] ); ?>" id="<?php echo esc_attr( $data['field_key'] ); ?>" class="directorist-form-element" <?php $listing_form->required( $data ); ?>>
 
-            <?php foreach ( $data['options'] as $key => $value ) : ?>
+            <?php if ( $show_empty_option ) : ?>
+
+                <option value="" <?php selected( '', $data['value'] ); ?>><?php echo esc_html( $placeholder ); ?></option>
+
+            <?php endif; ?>
+
+            <?php foreach ( $options as $value ) : ?>
 
                 <option value="<?php echo esc_attr( $value['option_value'] )?>" <?php selected( $value['option_value'], $data['value'] ); ?>><?php echo esc_attr( $value['option_label'] )?></option>
 

--- a/templates/listing-form/custom-fields/select.php
+++ b/templates/listing-form/custom-fields/select.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 8.9.4
+ * @version 8.9.5
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

### Main issue

An optional custom Dropdown rendered only its configured choices. When a new listing or an imported listing had no saved value for that field, the browser automatically selected the first choice because the `<select>` had no empty option. Saving the form could then store that first choice even though the user never selected it.

The CSV importer itself does not assign the first choice for an empty cell; the unintended value came from the dropdown's rendered default state when the listing was later edited and saved.

### Solution

- Add an empty `Select...` option to optional custom Dropdown fields.
- Use the configured field placeholder when one exists.
- Preserve the selected state for listings that already have a saved value.
- Avoid adding a second empty option when the field already defines one.
- Keep required Dropdown behavior unchanged.

### Easy test cases

1. Add an optional custom Dropdown with `New` and `Used` choices, then open the Add Listing form. Confirm `Select...` is selected by default.
2. Save the listing without choosing a value. Confirm the field remains empty and is not shown as `New` on the listing.
3. Select `Used`, save, and reopen the listing. Confirm `Used` remains selected.
4. Import a listing with the Dropdown CSV cell empty, then edit and save it without choosing a value. Confirm the field remains empty.
5. Make the Dropdown required. Confirm its existing behavior is unchanged and no empty option is added.
6. Configure an empty option manually. Confirm only one empty option appears.

### Verification performed

- PHP syntax check
- PHPCS on the changed template
- PHP 8.1+ compatibility check on the changed template
- Runtime rendering checks for empty, saved, required, existing-empty, and custom-placeholder cases
- Runtime submission check confirming an empty optional value is removed from listing metadata

## Any linked issues

- TeamSync issue #3246: https://team.sovware.com/support/directorist/3246
- Help Scout conversation #6226: https://secure.helpscout.net/conversation/3422925278/6226?viewId=8936453

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
