### PR TITLE
Add normalized contact data for anonymous users

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4890,6 +4890,49 @@ function directorist_is_guest_user( $user_id = 0 ) {
     return ( 'guest' === $user_type );
 }
 
+/**
+ * Get a normalized contact for a registered or anonymous user.
+ *
+ * Extensions can use the fallback values for flows that do not require a
+ * WordPress account, such as guest checkout or booking.
+ *
+ * @since 8.9.4
+ *
+ * @param int|WP_User $user     User ID or user object.
+ * @param array       $fallback Optional anonymous contact data.
+ * @return array{id: int, email: string, name: string} Normalized contact data.
+ */
+function directorist_get_user_contact( $user = 0, $fallback = [] ) {
+    $fallback = wp_parse_args(
+        $fallback,
+        [
+            'email' => '',
+            'name'  => '',
+        ]
+    );
+
+    if ( ! $user instanceof WP_User ) {
+        $user = get_userdata( absint( $user ) );
+    }
+
+    $contact = [
+        'id'    => $user ? (int) $user->ID : 0,
+        'email' => $user ? sanitize_email( $user->user_email ) : sanitize_email( $fallback['email'] ),
+        'name'  => $user ? sanitize_text_field( $user->display_name ) : sanitize_text_field( $fallback['name'] ),
+    ];
+
+    /**
+     * Filters normalized contact data for registered and anonymous users.
+     *
+     * @since 8.9.4
+     *
+     * @param array        $contact  Normalized contact data.
+     * @param WP_User|false $user     Resolved WordPress user, or false.
+     * @param array        $fallback Anonymous fallback values.
+     */
+    return apply_filters( 'directorist_user_contact', $contact, $user, $fallback );
+}
+
 function directorist_renewal_token_hash( $listing_id, $user_id ) {
     $token_str = 'cB0XtpVzGb180dgPi3hADW-' . $listing_id . '::' . $user_id;
     return wp_hash( $token_str, 'nonce' );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

### Main issue

Directorist extensions currently receive a `WP_User` only for registered visitors. A true guest flow has no reusable Core contract for carrying a sanitized email and display name, so extensions such as Booking can end up creating a WordPress account only to obtain contact data. That contradicts the expected guest-booking behavior and can trigger unwanted account emails.

### What changed

- Added `directorist_get_user_contact()` for registered and anonymous contacts.
- Registered users resolve from `WP_User` or user ID.
- Anonymous callers can supply sanitized fallback `email` and `name` values.
- Added the `directorist_user_contact` filter for extension-specific adjustments.

### How to test

1. Check out this Core PR together with the companion Booking PR listed below.
2. Run:
   `wp eval '$contact = directorist_get_user_contact( 0, [ "email" => "guest@example.com", "name" => "Guest User" ] ); print_r( $contact );'`
3. Confirm the result contains `id => 0`, `guest@example.com`, and `Guest User`.
4. Call the helper with a real user ID and confirm it returns that user's saved email and display name instead of the fallback.
5. Complete the guest-booking test from the companion PR and confirm no WordPress user is created.

### Dependency / companion PR

- Directorist Booking PR: https://github.com/sovware/directorist-booking/pull/54

## Any linked issues

- Client issue: https://team.sovware.com/support/directorist/3257
- Support conversation: https://secure.helpscout.net/conversation/3426004357/6295
- Companion Booking change fixes the reported guest-account, confirmation refresh, and field-icon problems.

### CI note

The repository PHPCS workflow currently exits before scanning code because `composer phpcs` supplies no file/directory and `phpcs.xml` has no default `<file>` target. A targeted local PHPCS run on `includes/helper-functions.php` completed with zero errors.

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)