### PR TITLE
Fix prepaid payment mapping and featured expiration

### DIFF
--- a/includes/classes/class-cron.php
+++ b/includes/classes/class-cron.php
@@ -103,9 +103,7 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
             }
 
             if ( directorist_is_monetization_enabled() && directorist_is_featured_listing_enabled() ) {
-                $featured_days = (int) get_directorist_option( 'featured_listing_time', 30 );
-                $orders        = directorist_order_repository();
-                $current_time  = directorist_now()->getTimestamp();
+                $orders = directorist_order_repository();
                 // Define the query
                 $args = [
                     'post_type'      => ATBDP_POST_TYPE,
@@ -126,20 +124,15 @@ if ( ! class_exists( 'ATBDP_Cron' ) ) :
                 // Start the Loop
                 if ( $listings->found_posts ) {
                     foreach ( $listings->posts as $listing ) {
-                        $order = $orders->get_latest_paid_featured_order_by_listing_id( $listing->ID );
+                        $has_paid_order         = $orders->listing_has_paid_featured_order( $listing->ID );
+                        $has_active_entitlement = $orders->listing_has_active_featured_entitlement( $listing->ID );
 
-                        if ( ! $order ) {
+                        if ( ! $has_paid_order || $has_active_entitlement ) {
                             continue;
                         }
 
-                        $expiration = ! empty( $order->expires_at )
-                            ? new \Directorist\Helpers\DateTime( $order->expires_at )
-                            : ( new \Directorist\Helpers\DateTime( $order->created_at ) )->add_days( $featured_days );
-
-                        if ( $expiration->getTimestamp() <= $current_time ) {
-                            do_action( 'atbdp_listing_featured_to_general', $listing->ID );
-                            update_post_meta( $listing->ID, '_featured', '' );
-                        }
+                        do_action( 'atbdp_listing_featured_to_general', $listing->ID );
+                        update_post_meta( $listing->ID, '_featured', '' );
                     }
                 }
             }

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -26,7 +26,7 @@ class FeaturedListingCheckout {
         }
 
         add_filter( 'directorist_checkout_types', [$this, 'add_checkout_type'] );
-        add_action( 'directorist_after_order_update', [$this, 'handle_after_order_update'] );
+        add_action( 'directorist_after_order_update', [$this, 'handle_after_order_update'], 10, 2 );
         add_filter( 'directorist_checkout_validation', [$this, 'validate_checkout'], 10, 2 );
         add_action( 'directorist_checkout_table', [$this, 'handle_checkout_table'], 10, 4 );
         add_filter( 'directorist_checkout_subtotal', [$this, 'handle_checkout_subtotal'], 10, 3 );
@@ -133,7 +133,7 @@ class FeaturedListingCheckout {
         $dto->set_listing_id( $request->get_param( 'listing_id' ) )->set_is_featured_listing( 1 )->set_ref_type( self::CHECKOUT_TYPE )->set_amount( $amount )->set_sub_total( $amount );
     }
 
-    public function handle_after_order_update( OrderDTO $dto ) {
+    public function handle_after_order_update( OrderDTO $dto, $old_order = null ) {
         if ( ! $this->is_featured_order( $dto ) ) {
             return;
         }
@@ -143,14 +143,16 @@ class FeaturedListingCheckout {
         }
 
         if ( Status::PAID === $dto->get_status() ) {
-            $order_expiration = $this->refresh_order_expiration( $dto );
+            $order_expiration = $this->is_paid_transition( $old_order )
+                ? $this->refresh_order_expiration( $dto )
+                : null;
 
             directorist_set_listing_featured( $dto->get_listing_id(), true );
 
             // Publish the listing if it's pending
             $listing = get_post( $dto->get_listing_id() );
 
-            if ( $listing ) {
+            if ( $listing && $order_expiration ) {
                 $this->update_listing_expiration( $listing, $order_expiration );
             }
 
@@ -160,6 +162,10 @@ class FeaturedListingCheckout {
         } elseif ( ! directorist_order_repository()->listing_has_active_featured_entitlement( $dto->get_listing_id() ) ) {
             directorist_set_listing_featured( $dto->get_listing_id(), false );
         }
+    }
+
+    private function is_paid_transition( $old_order ): bool {
+        return ! $old_order || ! isset( $old_order->status ) || Status::PAID !== $old_order->status;
     }
 
     private function refresh_order_expiration( OrderDTO $order ) {

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -173,15 +173,16 @@ class FeaturedListingCheckout {
             ? date_create_from_format( 'Y-m-d H:i:s', $listing_expiration, wp_timezone() )
             : false;
 
+
+        $order->set_expires_at( $order_expiration );
+        directorist_order_repository()->silent_update( $order );
+
         if ( $listing_expiration_date
             && $listing_expiration === $listing_expiration_date->format( 'Y-m-d H:i:s' )
             && $listing_expiration_date->getTimestamp() >= $order_expiration->getTimestamp()
         ) {
             return;
         }
-
-        $order->set_expires_at( $order_expiration );
-        directorist_order_repository()->silent_update( $order );
 
         update_post_meta( $listing->ID, '_expiry_date', $order_expiration->format( 'Y-m-d H:i:s' ) );
     }

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -157,7 +157,7 @@ class FeaturedListingCheckout {
             if ( $listing && 'publish' !== $listing->post_status ) {
                 directorist_set_listing_status( $dto->get_listing_id(), 'publish' );
             }
-        } else {
+        } elseif ( ! directorist_order_repository()->listing_has_active_featured_entitlement( $dto->get_listing_id() ) ) {
             directorist_set_listing_featured( $dto->get_listing_id(), false );
         }
     }

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -143,13 +143,15 @@ class FeaturedListingCheckout {
         }
 
         if ( Status::PAID === $dto->get_status() ) {
+            $order_expiration = $this->refresh_order_expiration( $dto );
+
             directorist_set_listing_featured( $dto->get_listing_id(), true );
 
             // Publish the listing if it's pending
             $listing = get_post( $dto->get_listing_id() );
 
             if ( $listing ) {
-                $this->updated_listing_expiration( $listing, $dto );
+                $this->update_listing_expiration( $listing, $order_expiration );
             }
 
             if ( $listing && 'publish' !== $listing->post_status ) {
@@ -160,22 +162,29 @@ class FeaturedListingCheckout {
         }
     }
 
-    private function updated_listing_expiration( $listing, OrderDTO $order ) {
+    private function refresh_order_expiration( OrderDTO $order ) {
+        $featured_days    = (int) get_directorist_option( 'featured_listing_time', 30 );
+        $order_expiration = directorist_now()->add_days( $featured_days );
+
+        $order->set_expires_at( $order_expiration );
+        $expiration_update = ( new OrderDTO() )
+            ->set_id( $order->get_id() )
+            ->set_expires_at( $order_expiration );
+
+        directorist_order_repository()->silent_update( $expiration_update );
+
+        return $order_expiration;
+    }
+
+    private function update_listing_expiration( $listing, $order_expiration ) {
         if ( get_post_meta( $listing->ID, '_never_expire', true ) ) {
             return;
         }
-
-        $featured_days    = (int) get_directorist_option( 'featured_listing_time', 30 );
-        $order_expiration = directorist_now()->add_days( $featured_days );
 
         $listing_expiration      = get_post_meta( $listing->ID, '_expiry_date', true );
         $listing_expiration_date = $listing_expiration
             ? date_create_from_format( 'Y-m-d H:i:s', $listing_expiration, wp_timezone() )
             : false;
-
-
-        $order->set_expires_at( $order_expiration );
-        directorist_order_repository()->silent_update( $order );
 
         if ( $listing_expiration_date
             && $listing_expiration === $listing_expiration_date->format( 'Y-m-d H:i:s' )

--- a/includes/classes/class-featured-listing-checkout.php
+++ b/includes/classes/class-featured-listing-checkout.php
@@ -143,7 +143,7 @@ class FeaturedListingCheckout {
         }
 
         if ( Status::PAID === $dto->get_status() ) {
-            $order_expiration = $this->is_paid_transition( $old_order )
+            $order_expiration = $this->should_refresh_order_expiration( $dto, $old_order )
                 ? $this->refresh_order_expiration( $dto )
                 : null;
 
@@ -166,6 +166,10 @@ class FeaturedListingCheckout {
 
     private function is_paid_transition( $old_order ): bool {
         return ! $old_order || ! isset( $old_order->status ) || Status::PAID !== $old_order->status;
+    }
+
+    private function should_refresh_order_expiration( OrderDTO $order, $old_order ): bool {
+        return $this->is_paid_transition( $old_order ) || ! $order->is_initialized( 'expires_at' );
     }
 
     private function refresh_order_expiration( OrderDTO $order ) {

--- a/includes/repositories/order-repository.php
+++ b/includes/repositories/order-repository.php
@@ -89,6 +89,35 @@ class OrderRepository extends Repository {
         return $order ? true : false;
     }
 
+    public function listing_has_active_featured_entitlement( int $listing_id ): bool {
+        $orders = $this->get_query_builder()
+            ->select( 'd_order.ref_type', 'd_order.created_at', 'd_order.expires_at' )
+            ->where( 'd_order.listing_id', $listing_id )
+            ->where( 'd_order.is_featured_listing', 1 )
+            ->where( 'd_order.status', OrderStatus::PAID )
+            ->get();
+
+        $current_time  = directorist_now()->getTimestamp();
+        $featured_days = (int) get_directorist_option( 'featured_listing_time', 30 );
+        $is_active     = false;
+
+        foreach ( $orders as $order ) {
+            if ( ! empty( $order->expires_at ) ) {
+                $is_active = ( new DateTime( $order->expires_at ) )->getTimestamp() > $current_time;
+            } elseif ( 'featured_listing' === $order->ref_type ) {
+                $is_active = ( new DateTime( $order->created_at ) )->add_days( $featured_days )->getTimestamp() > $current_time;
+            } else {
+                $is_active = true;
+            }
+
+            if ( $is_active ) {
+                break;
+            }
+        }
+
+        return (bool) apply_filters( 'directorist_listing_has_active_featured_entitlement', $is_active, $listing_id, $orders );
+    }
+
     public function get_latest_paid_featured_order_by_listing_id( int $listing_id ) {
         return $this->get_query_builder()
             ->select( 'd_order.created_at', 'd_order.expires_at' )

--- a/includes/repositories/payment-repository.php
+++ b/includes/repositories/payment-repository.php
@@ -9,6 +9,7 @@ use Directorist\Utils\Repositories\Repository;
 use Directorist\Utils\Database\Query\Builder;
 use Directorist\DTO\Payment\DTO;
 use Directorist\Enums\Order\Status as OrderStatus;
+use Directorist\Enums\Payment\Status as PaymentStatus;
 use Directorist\DBModels\Payment;
 
 class PaymentRepository extends Repository {
@@ -33,13 +34,32 @@ class PaymentRepository extends Repository {
      * @return int
      */
     public function create( \Directorist\Utils\DTO $dto ) {
-        $payment_id = parent::create( $dto );
+        $payment_id = $this->create_without_order_update( $dto );
+        $payment    = $payment_id ? $this->get_last_payment( $dto->get_order_id() ) : null;
 
-        if ( $dto->is_initialized( 'status' ) && $dto->get_status() === OrderStatus::PAID ) {
+        if ( ! $payment || (int) $payment->id !== $payment_id || $payment->status !== $dto->get_status() ) {
+            return 0;
+        }
+
+        if ( $dto->is_initialized( 'status' ) && $dto->get_status() === PaymentStatus::PAID ) {
             $this->order_repository->update_status( $dto->get_order_id(), OrderStatus::PAID );
         }
 
         return $payment_id;
+    }
+
+    /**
+     * Create a payment without synchronizing the related order status.
+     *
+     * @param \Directorist\Utils\DTO $dto Payment data.
+     * @return int Payment ID, or zero when the insert fails.
+     */
+    public function create_without_order_update( \Directorist\Utils\DTO $dto ) {
+        global $wpdb;
+
+        $payment_id = parent::create( $dto );
+
+        return $wpdb->last_error ? 0 : $payment_id;
     }
 
     public function update_status_by_order_id( int $order_id, string $status ): int {

--- a/includes/repositories/payment-repository.php
+++ b/includes/repositories/payment-repository.php
@@ -35,7 +35,7 @@ class PaymentRepository extends Repository {
      */
     public function create( \Directorist\Utils\DTO $dto ) {
         $payment_id = $this->create_without_order_update( $dto );
-        $payment    = $payment_id ? $this->get_last_payment( $dto->get_order_id() ) : null;
+        $payment    = $payment_id ? $this->get_by_id( $payment_id ) : null;
 
         if ( ! $payment || (int) $payment->id !== $payment_id || $payment->status !== $dto->get_status() ) {
             return 0;

--- a/includes/rest-api/Version1/class-orders-controller.php
+++ b/includes/rest-api/Version1/class-orders-controller.php
@@ -161,14 +161,18 @@ class Orders_Controller extends Abstract_Controller {
 
             $payment_dto        = apply_filters( 'directorist_rest_legacy_order_create_payment_dto', $payment_dto, $request, $dto );
             $payment_repository = directorist_payment_repository();
-            $payment_id         = $payment_repository->create( $payment_dto );
+            $payment_id         = $payment_repository->create_without_order_update( $payment_dto );
             $payment            = $payment_repository->get_last_payment( $order_id );
 
-            if ( ! $payment_id || ! $payment || $payment->status !== $payment_dto->get_status() ) {
+            if ( ! $payment_id || ! $payment || (int) $payment->id !== $payment_id || $payment->status !== $payment_dto->get_status() ) {
                 $payment_repository->delete_by( 'order_id', $order_id );
                 $order_repository->delete_by_id( $order_id );
 
                 return new WP_Error( 'rest_payment_create_failed', __( 'Unable to create payment.', 'directorist' ), array( 'status' => 500 ) );
+            }
+
+            if ( OrderStatus::PAID === $dto->get_status() ) {
+                $order_repository->update_status( $order_id, OrderStatus::PAID );
             }
         }
 
@@ -270,6 +274,9 @@ class Orders_Controller extends Abstract_Controller {
     protected function prepare_legacy_order_data( $order, WP_REST_Request $request ): array {
         $payment = ! empty( $order->payment ) ? $order->payment : null;
         $plan_id = $this->get_plan_id( $order );
+        $status  = OrderStatus::PREPAID === ( $order->status ?? '' )
+            ? $order->status
+            : ( $payment->status ?? $order->status ?? '' );
 
         $data = array(
             'id'                          => (int) $order->id,
@@ -285,7 +292,7 @@ class Orders_Controller extends Abstract_Controller {
             'remaining_featured_listings' => 0,
             'amount'                      => round( (float) ( $order->amount ?? 0 ), 2 ),
             'currency'                    => (string) ( $order->currency ?? '' ),
-            'payment_status'              => $this->current_status_to_legacy_status( $payment->status ?? $order->status ?? '' ),
+            'payment_status'              => $this->current_status_to_legacy_status( $status ),
             'payment_gateway'             => (string) ( $payment->method ?? '' ),
             'transaction_id'              => (string) ( $payment->transaction_id ?? '' ),
             'created_by'                  => 'web',

--- a/includes/rest-api/Version1/class-orders-controller.php
+++ b/includes/rest-api/Version1/class-orders-controller.php
@@ -162,7 +162,7 @@ class Orders_Controller extends Abstract_Controller {
             $payment_dto        = apply_filters( 'directorist_rest_legacy_order_create_payment_dto', $payment_dto, $request, $dto );
             $payment_repository = directorist_payment_repository();
             $payment_id         = $payment_repository->create_without_order_update( $payment_dto );
-            $payment            = $payment_repository->get_last_payment( $order_id );
+            $payment            = $payment_id ? $payment_repository->get_by_id( $payment_id ) : null;
 
             if ( ! $payment_id || ! $payment || (int) $payment->id !== $payment_id || $payment->status !== $payment_dto->get_status() ) {
                 $payment_repository->delete_by( 'order_id', $order_id );

--- a/includes/rest-api/Version1/class-orders-controller.php
+++ b/includes/rest-api/Version1/class-orders-controller.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use Directorist\DTO\Order\DTO as OrderDTO;
 use Directorist\DTO\Payment\DTO as PaymentDTO;
 use Directorist\Enums\Order\Status as OrderStatus;
+use Directorist\Enums\Payment\Status as PaymentStatus;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -140,7 +141,8 @@ class Orders_Controller extends Abstract_Controller {
 
         $dto = apply_filters( 'directorist_rest_legacy_order_create_dto', $dto, $request );
 
-        $order_id = directorist_order_repository()->create( $dto );
+        $order_repository = directorist_order_repository();
+        $order_id         = $order_repository->create( $dto );
 
         if ( ! $order_id ) {
             return new WP_Error( 'invalid_order', __( 'Unable to create order.', 'directorist' ), array( 'status' => 400 ) );
@@ -153,11 +155,21 @@ class Orders_Controller extends Abstract_Controller {
                 ->set_order_id( $order_id )
                 ->set_amount( $amount )
                 ->set_currency( $currency )
-                ->set_status( $this->legacy_status_to_current_status( $legacy_status ) )
+                ->set_status( $this->legacy_payment_status_to_current_status( $legacy_status ) )
                 ->set_method( $gateway )
                 ->set_transaction_id( $transaction_id ? $transaction_id : null );
 
-            directorist_payment_repository()->create( apply_filters( 'directorist_rest_legacy_order_create_payment_dto', $payment_dto, $request, $dto ) );
+            $payment_dto        = apply_filters( 'directorist_rest_legacy_order_create_payment_dto', $payment_dto, $request, $dto );
+            $payment_repository = directorist_payment_repository();
+            $payment_id         = $payment_repository->create( $payment_dto );
+            $payment            = $payment_repository->get_last_payment( $order_id );
+
+            if ( ! $payment_id || ! $payment || $payment->status !== $payment_dto->get_status() ) {
+                $payment_repository->delete_by( 'order_id', $order_id );
+                $order_repository->delete_by_id( $order_id );
+
+                return new WP_Error( 'rest_payment_create_failed', __( 'Unable to create payment.', 'directorist' ), array( 'status' => 500 ) );
+            }
         }
 
         do_action( 'atbdp_order_created', $order_id, $listing_id );
@@ -313,6 +325,20 @@ class Orders_Controller extends Abstract_Controller {
         );
 
         return $map[ $status ] ?? OrderStatus::PENDING;
+    }
+
+    protected function legacy_payment_status_to_current_status( string $status ): string {
+        $map = array(
+            'created'   => PaymentStatus::PENDING,
+            'pending'   => PaymentStatus::PENDING,
+            'prepaid'   => PaymentStatus::PAID,
+            'completed' => PaymentStatus::PAID,
+            'failed'    => PaymentStatus::FAILED,
+            'cancelled' => PaymentStatus::CANCELLED,
+            'refunded'  => PaymentStatus::REFUNDED,
+        );
+
+        return $map[ $status ] ?? PaymentStatus::PENDING;
     }
 
     protected function current_status_to_legacy_status( string $status ): string {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

### Why is this PR needed?

Legacy prepaid REST orders could write an invalid payment status, producing corrupted or missing payment rows while still returning a successful response. Concurrent payment inserts could make a successful insert appear to fail. Featured-listing updates could renew an already-paid entitlement indefinitely, while orders inserted directly as paid could miss expiration initialization. Failed or expired orders could also remove featured status even when another paid entitlement remained active.

### What is done?

- Maps legacy prepaid payments to paid while preserving the order and legacy response as prepaid.
- Persists legacy REST payments without automatically synchronizing the order status.
- Validates each inserted payment by its returned ID before synchronizing completed orders or firing paid-order hooks.
- Removes partial payment and order records and returns an HTTP 500 error when payment creation fails.
- Prevents the payment repository from synchronizing paid orders when the payment insert fails or stores an unexpected status.
- Preserves an existing active standalone or plan-backed featured entitlement when another featured order fails.
- Refreshes featured expiration when an order transitions from a non-paid status to paid.
- Initializes missing expiration for featured orders inserted directly as paid.
- Prevents duplicate callbacks and paid-order updates with an existing expiration from extending an entitlement.
- Checks every paid featured order before cron removes featured status.
- Preserves later and never-expiring listing dates while keeping order expiration available to cron.
- Uses a focused expiration update so nullable order fields do not cause strict-MySQL update failures.

### How to test

1. Enable monetization and featured listings, and set the featured duration to 30 days.
2. Create a legacy REST order with payment_status set to prepaid and verify the order remains prepaid, the payment is paid, and the response reports prepaid.
3. Repeat the prepaid request with strict and non-strict MySQL modes and verify exactly one valid payment row is created without firing a paid-order update hook.
4. Create a completed legacy REST order and verify the payment exists before the paid-order hook runs, while the order, payment, and response report the completed state.
5. Force payment insertion to fail under strict MySQL and verify the endpoint returns HTTP 500, creates no order or payment row, and does not fire paid-order or success hooks.
6. Insert two payments for the same order so a newer payment exists before the first is validated; verify the first payment succeeds by its own ID and synchronizes its paid order.
7. Create a featured listing with an active paid standalone order, fail a later featured renewal, and verify the listing remains featured.
8. Change a prepaid featured order to paid and verify its order and listing expirations are set to the payment time plus 30 days.
9. Create a completed featured order directly as paid without an expiration and verify its first paid update initializes the order and listing expirations.
10. Update that paid order again and repeat its paid payment callback; verify neither expiration changes.
11. Create two paid featured orders for one listing, with the lower-ID order active and the higher-ID order expired; run cron and verify the listing remains featured.
12. Expire both orders, rerun cron, and verify the listing is unfeatured.
13. Verify a manually featured listing with no paid standalone order remains featured after cron.
14. Verify a later listing expiration and a never-expiring listing remain unchanged while their featured order expiration is saved.
15. Complete a zero-cost featured checkout and verify the order is paid, has a fresh expiration, and the payment receipt remains correct.

## Any linked issues
N/A

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
