### PR TITLE
Remove live preview label from badge conditions

### DIFF
--- a/assets/src/js/admin/vue/apps/settings-manager/components/Settings_Badges_Manager.vue
+++ b/assets/src/js/admin/vue/apps/settings-manager/components/Settings_Badges_Manager.vue
@@ -361,7 +361,6 @@
                     </button>
                   </div>
                 </div>
-                <span class="cptm-badge-preview-hint">Live preview</span>
               </div>
 
               <div class="cptm-badge-condition-list">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

### Main issue

The expanded badge condition editor displays a `Live preview` label beside the match-mode controls, but that area does not provide a separate preview action or preview panel. The label is therefore misleading, particularly while editing a custom badge.

### What changed

- Removed the `Live preview` label from the badge condition header.
- Kept badge matching, condition controls, saved rules, and frontend output unchanged.

### How to test

1. Build the legacy admin assets and open **Directorist > Settings > Appearance > Badges**.
2. Add or expand a custom badge.
3. Confirm the **Match conditions** header shows the **All (AND)** and **Any (OR)** controls without the `Live preview` label.
4. Add or edit a condition and save the settings; confirm the badge rule still persists normally.

### Screenshot reference

The supplied before screenshot highlights the removed `Live preview` label to the right of the custom badge match-condition controls.

## Any linked issues
N/A

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
