### PR TITLE
fix: preserve zero values in number fields

### DIFF
--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -542,10 +542,6 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
                         return false;
                     }
 
-                    if ( is_numeric( $value ) && $value == 0 ) {
-                        return false;
-                    }
-
                     return true;
                 }, ARRAY_FILTER_USE_BOTH
             );

--- a/includes/classes/class-submission-controller.php
+++ b/includes/classes/class-submission-controller.php
@@ -510,10 +510,6 @@ class SubmissionController {
                     return false;
                 }
 
-                if ( is_numeric( $value ) && $value == 0 ) {
-                    return false;
-                }
-
                 return true;
             }, ARRAY_FILTER_USE_BOTH 
         );

--- a/includes/fields/class-directorist-number-field.php
+++ b/includes/fields/class-directorist-number-field.php
@@ -34,6 +34,10 @@ class Number_Field extends Base_Field {
     }
 
     public function sanitize( $posted_data ) {
+        if ( $this->is_value_empty( $posted_data ) ) {
+            return '';
+        }
+
         return round( (float) $this->get_value( $posted_data ), 2 );
     }
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4628,10 +4628,6 @@ function directorist_filter_listing_empty_metadata( $meta_data ) {
                 return false;
             }
 
-            if ( is_numeric( $value ) && $value == 0 ) {
-                return false;
-            }
-
             return true;
         }, ARRAY_FILTER_USE_BOTH
     );

--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -997,8 +997,12 @@ class Directorist_Listings {
 
         if ( isset( $_REQUEST['custom_field'] ) ) {
             // Multi-dimensional array, sanitized inside
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-            $custom_fields = array_filter( wp_unslash( $_REQUEST['custom_field'] ) );
+            $custom_fields = array_filter(
+                // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+                wp_unslash( $_REQUEST['custom_field'] ), static function( $value ) {
+                    return is_array( $value ) ? ! empty( $value ) : null !== $value && '' !== $value;
+                }
+            );
 
             foreach ( $custom_fields as $key => $values ) {
                 $key = sanitize_text_field( $key );

--- a/includes/model/SearchForm.php
+++ b/includes/model/SearchForm.php
@@ -732,7 +732,7 @@ class Directorist_Listing_Search_Form {
         $field_data['lazy_load'] = false;
 
         if ( $this->is_custom_field( $field_data ) ) {
-            if ( ! empty( $_REQUEST['custom_field'][$key] ) ) {
+            if ( isset( $_REQUEST['custom_field'][$key] ) ) {
                 $value = is_array( $_REQUEST['custom_field'][$key] ) ? array_map( 'sanitize_text_field', wp_unslash( $_REQUEST['custom_field'][$key] ) ) : sanitize_text_field( wp_unslash( $_REQUEST['custom_field'][$key] ) );
             } else {
                 $value = '';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

### Issue

A custom Number field value of `0` was treated as empty in multiple submission paths, so the metadata was removed instead of saved. The search request also used PHP's default `array_filter()`, which removed the string value `"0"`; as a result, an exact search for zero ran without the intended number-field meta query.

### Fix

- Distinguish a genuinely blank Number field from an explicit numeric zero before sanitizing.
- Preserve numeric zero in the current submission controller, legacy submission path, and admin/metabox metadata filtering.
- Preserve `"0"` in custom-field search requests and repopulate it in the search UI.
- Keep the existing behavior for blank optional fields, exact nonzero number searches, text partial matching, and number ranges.

### Test cases

1. Submit a new listing with the custom Number field set to `0`; confirm the metadata exists and is stored as zero.
2. Edit the value from `0` to `2.50`, then back to `0`; confirm each value is preserved.
3. Clear the optional Number field; confirm its metadata is deleted rather than converted to zero.
4. Submit a new listing with the optional Number field blank; confirm no zero metadata is created.
5. Search the Number field for `0`; confirm only the zero-valued listing is returned and the query value is retained.
6. Search the Number field for `2`; confirm the listing with `3` is not returned.
7. Search the Number field with the `2-3` range; confirm both boundary values are returned.
8. Verify the exact-zero and range result layouts on desktop and mobile and confirm no horizontal overflow or visible listing-card regression.

## Any linked issues

- TeamSync support ticket: https://team.sovware.com/support/directorist/3285

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
