### PR TITLE
fix: handle unavailable listing type and map directions

### DIFF
--- a/includes/directorist-directory-functions.php
+++ b/includes/directorist-directory-functions.php
@@ -41,6 +41,10 @@ function directorist_get_listing_form_fields( $directory_id, $context = [] ) {
         unset( $fields['view_count'] );
     }
 
+    if ( isset( $fields['listing_type'] ) && ( is_fee_manager_active() || ! directorist_is_featured_listing_enabled( $context ) ) ) {
+        unset( $fields['listing_type'] );
+    }
+
     return $fields;
 }
 

--- a/templates/archive/fields/google-map.php
+++ b/templates/archive/fields/google-map.php
@@ -86,7 +86,10 @@
                     </div>
                 <?php } ?>
 
-                <?php if ( ! empty( $ls_data['address'] ) || ! empty( $ls_data['phone'] ) ) { ?>
+                <?php
+                $has_direction = ! empty( $display_direction_map ) && ( ( ! empty( $ls_data['manual_lat'] ) && ! empty( $ls_data['manual_lng'] ) ) || ! empty( $ls_data['address'] ) );
+
+                if ( ! empty( $ls_data['address'] ) || ! empty( $ls_data['phone'] ) || $has_direction ) { ?>
                     <div class="map-listing-card-single__content__info">
                         <?php
                         if ( ! empty( $ls_data['address'] ) ) {
@@ -108,6 +111,23 @@
                                     <a href='./' class='map-info-link'><?php echo esc_html( $ls_data['phone'] ); ?></a>
                                 </div>
                                 <?php
+                        }
+
+                        if ( $has_direction ) {
+                            $direction_destination = ! empty( $ls_data['manual_lat'] ) && ! empty( $ls_data['manual_lng'] ) ? $ls_data['manual_lat'] . ',' . $ls_data['manual_lng'] : $ls_data['address'];
+                            $direction_url         = add_query_arg(
+                                array(
+                                    'api'         => 1,
+                                    'destination' => $direction_destination,
+                                ),
+                                'https://www.google.com/maps/dir/'
+                            );
+                            ?>
+                            <div class='directorist-info-item map-listing-card-single__content__direction'>
+                                <?php directorist_icon( 'fas fa-directions' ); ?>
+                                <a href='<?php echo esc_url( $direction_url ); ?>' target='_blank' rel='noopener noreferrer'><?php esc_html_e( 'Get Directions', 'directorist' ); ?></a>
+                            </div>
+                            <?php
                         }
                         ?>
                     </div>

--- a/templates/archive/fields/openstreet-map.php
+++ b/templates/archive/fields/openstreet-map.php
@@ -81,7 +81,10 @@
             </div>
         <?php } ?>
 
-        <?php if ( ! empty( $ls_data['address'] ) || ! empty( $ls_data['phone'] ) ) { ?>
+        <?php
+        $has_direction = ! empty( $display_direction_map ) && ( ( ! empty( $ls_data['manual_lat'] ) && ! empty( $ls_data['manual_lng'] ) ) || ! empty( $ls_data['address'] ) );
+
+        if ( ! empty( $ls_data['address'] ) || ! empty( $ls_data['phone'] ) || $has_direction ) { ?>
             <div class="map-listing-card-single__content__info">
                 <?php
                 if ( ! empty( $ls_data['address'] ) ) {
@@ -103,6 +106,23 @@
                             <a href='./' class='map-info-link'><?php echo esc_html( $ls_data['phone'] ); ?></a>
                         </div>
                         <?php
+                }
+
+                if ( $has_direction ) {
+                    $direction_destination = ! empty( $ls_data['manual_lat'] ) && ! empty( $ls_data['manual_lng'] ) ? $ls_data['manual_lat'] . ',' . $ls_data['manual_lng'] : $ls_data['address'];
+                    $direction_url         = add_query_arg(
+                        array(
+                            'api'         => 1,
+                            'destination' => $direction_destination,
+                        ),
+                        'https://www.google.com/maps/dir/'
+                    );
+                    ?>
+                    <div class='directorist-info-item map-listing-card-single__content__direction'>
+                        <?php directorist_icon( 'fas fa-directions' ); ?>
+                        <a href='<?php echo esc_url( $direction_url ); ?>' target='_blank' rel='noopener noreferrer'><?php esc_html_e( 'Get Directions', 'directorist' ); ?></a>
+                    </div>
+                    <?php
                 }
                 ?>
             </div>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

Listing Type field:

1. Disable Featured Listings while Fee Manager is inactive.
2. Keep a legacy required Listing Type field in the directory submission form, then open or submit Add Listing.
3. Before this change, the unavailable field remains in the normalized field list and can trigger missing general label output or required-field validation. After this change, the field is omitted whenever it is not available. Re-enable Featured Listings and confirm the field is retained.

Archive map directions:

1. Enable the map card Get Directions setting and open a Google Maps or OpenStreetMap archive map card for a listing with coordinates or an address.
2. Confirm a Get Directions link is rendered and opens Google Maps with the listing coordinates as the destination. A listing without coordinates falls back to its address.
3. Disable the setting and confirm the link is omitted.

Verification completed:

- WP-CLI fixture: disabled Listing Type omitted; enabled Listing Type retained.
- Template render: Google and OpenStreetMap links include the expected destination.
- Template render: disabled setting omits the link.
- Scoped PHPCS: zero errors; three pre-existing alignment warnings in directorist-directory-functions.php.

## Any linked issues
Fixes #

TeamSync task: https://team.sovware.com/support/directorist/3273
Help Scout conversation: https://secure.helpscout.net/conversation/3435845567/5025

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)