### PR TITLE
Fix featured widget review visibility

### DIFF
--- a/templates/widgets/featured-listing.php
+++ b/templates/widgets/featured-listing.php
@@ -33,7 +33,8 @@ $featured_args = [
 apply_filters( "directorist_widget_featured_listings_query_arguments", $featured_args );
 
 $featured_listings = new WP_Query( $featured_args );
-$default_icon = 'las la-tags';
+$default_icon     = 'las la-tags';
+$reviews_enabled = directorist_is_review_enabled();
 ?>
 <div class="directorist-card__body">
     <div class="directorist-widget-listing">
@@ -41,10 +42,12 @@ $default_icon = 'las la-tags';
         if ( $featured_listings->have_posts() ) {
             while ( $featured_listings->have_posts() ) {
                 $featured_listings->the_post();
-                $review_rating = directorist_get_listing_rating( get_the_ID() );
-                $review_count  = directorist_get_listing_review_count( get_the_ID() );
-                /* translators: %s: Number of reviews */
-                $review_text   = sprintf( _n( '%s review', '%s reviews', $review_count, 'directorist' ), number_format_i18n( $review_count ) );
+                if ( $reviews_enabled ) {
+                    $review_rating = directorist_get_listing_rating( get_the_ID() );
+                    $review_count  = directorist_get_listing_review_count( get_the_ID() );
+                    /* translators: %s: Number of reviews */
+                    $review_text = sprintf( _n( '%s review', '%s reviews', $review_count, 'directorist' ), number_format_i18n( $review_count ) );
+                }
                 // get only one parent or high level term object
                 $listing_img = directorist_get_listing_gallery_images( get_the_ID() );
                 $listing_prv_img = directorist_get_listing_preview_image( get_the_ID() );
@@ -70,13 +73,15 @@ $default_icon = 'las la-tags';
                     </div>
                     <div class="directorist-widget-listing__content">
                         <h4 class="directorist-widget-listing__title"><a href="<?php echo esc_url( get_post_permalink( get_the_ID() ) ); ?>"><?php echo esc_html( stripslashes( get_the_title() ) ); ?></a></h4>
-                        <div class="directorist-widget-listing__meta">
-                            <span class="directorist-widget-listing__rating">
-                                <?php Markup::show_rating_stars( $review_rating );?>
-                            </span>
-                            <span class="directorist-widget-listing__rating-point"><?php echo esc_html( $review_rating ); ?></span>
-                            <span class="directorist-widget-listing__reviews">(<?php echo esc_html( $review_text ) ?>)</span>
-                        </div>
+                        <?php if ( $reviews_enabled ) : ?>
+                            <div class="directorist-widget-listing__meta">
+                                <span class="directorist-widget-listing__rating">
+                                    <?php Markup::show_rating_stars( $review_rating );?>
+                                </span>
+                                <span class="directorist-widget-listing__rating-point"><?php echo esc_html( $review_rating ); ?></span>
+                                <span class="directorist-widget-listing__reviews">(<?php echo esc_html( $review_text ) ?>)</span>
+                            </div>
+                        <?php endif; ?>
                         <span class="directorist-widget-listing__price">
                             <?php if ( ! empty( $price ) && ( 'price' === $listing_pricing ) ) { ?>
                                 <span><?php atbdp_display_price( $price ); ?></span>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
The Featured Listings widget rendered rating stars, rating points, and review counts even when Directorist reviews were disabled. This change makes the widget respect the global review setting while preserving the existing output when reviews are enabled.

How to reproduce the issue or how to test the changes

1. Add the Directorist Featured Listings widget to a sidebar and ensure it has a published featured listing to display.
2. Go to **Directorist > Settings > Listings > Review** and disable reviews.
3. Before this change, the widget still displays rating/review metadata. After this change, the listing remains visible but the rating/review metadata is omitted.
4. Enable reviews again and confirm the existing rating/review metadata returns.

### Before
https://prnt.sc/m_dKc0nKUrF9
### After
https://prnt.sc/rjG5WCjOUhKK

### Verification
- `php -l templates/widgets/featured-listing.php`
- `composer phpcs -- --warning-severity=0 -- templates/widgets/featured-listing.php`
- Runtime render check: reviews disabled = `0` rating-meta blocks; reviews enabled = `1` rating-meta block; the listing rendered in both states.
- Secure `pull_request` PHPCS workflow: [passed](https://github.com/sovware/directorist/actions/runs/34089124854/job/101639257477).
- The duplicate legacy `pull_request_target` check fails before scanning any file with `You must supply at least one file or directory to process`; this is a default-branch workflow invocation issue, not a PHPCS violation in this PR.

## Any linked issues
TeamSync: https://team.sovware.com/support/directorist/3273

Help Scout: https://secure.helpscout.net/conversation/3370614583/5025

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
