### PR TITLE
Fix CSV import validation for WordPress upload filenames

### DIFF
--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -1123,19 +1123,21 @@ if ( ! class_exists( 'ATBDP_Tools' ) ) :
                 return new WP_Error( 'invalid_csv_file', 'Invalid file path or file does not exists.' );
             }
 
-            if ( ! wp_check_filetype( $file )['ext'] === 'csv' ) {
-                return new WP_Error( 'invalid_csv_file', 'The file must be a CSV file.' );
-            }
+            $filename = wp_basename( $file );
 
-            $mime_type = mime_content_type( $file );
-            if ( ! in_array( $mime_type, [ 'text/csv','text/plain', 'application/csv' ], true ) ) {
-                return new WP_Error(
-                    'invalid_csv_file',
-                    sprintf(
-                        'Invalid file type. Only text/plain, text/csv, and application/csv are supported, given "%s".',
-                        $mime_type
-                    )
-                );
+            // WordPress appends .txt and may add a numeric suffix to importer uploads.
+            $filename = preg_replace( '/\.csv(?:-\d+)?\.txt$/i', '.csv', $filename );
+
+            $file_type = wp_check_filetype_and_ext(
+                $file,
+                $filename,
+                [
+                    'csv' => 'text/csv',
+                ]
+            );
+
+            if ( 'csv' !== $file_type['ext'] || 'text/csv' !== $file_type['type'] ) {
+                return new WP_Error( 'invalid_csv_file', 'The file must be a valid CSV file.' );
             }
 
             return $file;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
CSV import validation called `mime_content_type()` directly, which causes a fatal error when PHP Fileinfo is unavailable. The previous extension condition also compared a negated boolean with `csv`, allowing invalid extensions to bypass that check.

This change uses WordPress's `wp_check_filetype_and_ext()` for extension and MIME validation. It also normalizes the temporary `.csv.txt` and deduplicated `.csv-N.txt` filenames created by `wp_import_handle_upload()` before checking the logical filename, while still validating the contents at the real uploaded path.

How to reproduce the issue or test the changes:

1. Open **Directorist → Settings → Tools → Listings → Import**, upload a valid CSV, and repeat the upload so WordPress creates a deduplicated `.csv-N.txt` attachment filename.
2. Continue to the column-mapping step and verify that the valid CSV is accepted and its rows and columns are displayed.
3. Verify that an ordinary TXT file and a PHP file renamed as CSV are rejected, and that validation does not call `mime_content_type()` directly when Fileinfo is unavailable.

Local verification:

- `php -l includes/classes/class-tools.php` using PHP 8.2
- `vendor/bin/phpcs -n --standard=phpcs.xml includes/classes/class-tools.php`
- `vendor/bin/phpcs -p includes/classes/class-tools.php --standard=PHPCompatibilityWP --severity=1 --runtime-set testVersion 7.4- --extensions=php`
- WordPress runtime fixtures: `.csv.txt` and `.csv-N.txt` attachments accepted; ordinary TXT and disguised PHP rejected
- Visual verification on `directorist.local`: deduplicated CSV displayed “Found 30 listings” and rendered the column-mapping table
- `git diff --check origin/development...HEAD`

Notes:

- GitHub's `PHPCS Check` workflow stops during checkout because its `pull_request_target` configuration rejects fork code unless `allow-unsafe-pr-checkout` is enabled. The focused PHPCS and PHPCompatibility checks pass locally.

## Any linked issues
- TeamSync: https://team.sovware.com/support/directorist/3306
- Help Scout: https://secure.helpscout.net/conversation/3441200565/6585
- GitHub: https://github.com/sovware/directorist/pull/3003

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)

## Files changed

- `includes/classes/class-tools.php` — Validate CSV imports through WordPress while supporting the temporary filenames generated by the core importer.
