### PR TITLE
Fix map address search with reordered postal codes

### DIFF
--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -1171,11 +1171,8 @@ class Directorist_Listings {
                 'units'     => $this->radius_search_unit
             ];
         } elseif ( ! empty( $_REQUEST['address'] ) ) {
-            $meta_queries['_address'] = [
-                'key'     => '_address',
-                'value'   => sanitize_text_field( wp_unslash( $_REQUEST['address'] ) ),
-                'compare' => 'LIKE'
-            ];
+            $address                  = sanitize_text_field( wp_unslash( $_REQUEST['address'] ) );
+            $meta_queries['_address'] = $this->get_address_meta_query( $address );
         }
 
         if ( 'zip' == $this->radius_search_based_on && ! empty( $_REQUEST['miles'] ) && ! empty( $_REQUEST['zip_cityLat'] ) && ! empty( $_REQUEST['zip_cityLng'] ) ) {
@@ -1222,6 +1219,57 @@ class Directorist_Listings {
         }
 
         return apply_filters( 'atbdp_listing_search_query_argument', $args );
+    }
+
+    /**
+     * Build the address fallback meta query.
+     *
+     * Map APIs can return a locality and postal code in a different order than
+     * the saved listing address. Match each term when a postal code is present
+     * so searches such as "Nègrepelisse 82800" can find an address containing
+     * "82800 Nègrepelisse".
+     *
+     * @param string $address Address submitted by the search form.
+     * @return array
+     */
+    private function get_address_meta_query( $address ) {
+        $address_query = [
+            'key'     => '_address',
+            'value'   => $address,
+            'compare' => 'LIKE',
+        ];
+
+        $terms = preg_split( '/[^\p{L}\p{N}]+/u', $address, -1, PREG_SPLIT_NO_EMPTY );
+
+        if ( empty( $terms ) || count( $terms ) < 2 ) {
+            return $address_query;
+        }
+
+        $has_postal_code = false;
+
+        foreach ( $terms as $term ) {
+            if ( preg_match( '/^\d{4,10}$/', $term ) ) {
+                $has_postal_code = true;
+                break;
+            }
+        }
+
+        if ( ! $has_postal_code ) {
+            return $address_query;
+        }
+
+        $terms         = array_values( array_unique( $terms ) );
+        $address_query = [ 'relation' => 'AND' ];
+
+        foreach ( $terms as $term ) {
+            $address_query[] = [
+                'key'     => '_address',
+                'value'   => $term,
+                'compare' => 'LIKE',
+            ];
+        }
+
+        return $address_query;
     }
 
     public function archive_view_template() {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
When a search form uses the Map API location source without a radius field, Directorist falls back to a single `_address LIKE <submitted address>` meta query. Map providers can return a locality and postal code in a different order from the saved listing address, so a search such as `Nègrepelisse 82800` does not match a stored address containing `82800 Nègrepelisse` even though both values identify the same location.

This change builds an order-independent nested address query when the submitted value contains a postal code. Each unique alphanumeric term must still be present in `_address`, which resolves the ordering mismatch without broadening the result to addresses missing any requested term. Single-term and non-postal address searches retain the existing full-value `LIKE` query, and coordinate-based radius searches are unchanged.

How to reproduce the issue or test the changes:

1. Configure a search form location field to use **Display from Map API** without adding a radius-search field.
2. Create a published listing whose `_address` contains `82800 Nègrepelisse`, then search with the Map API value `Nègrepelisse 82800` and a keyword matching that listing.
3. On the base branch, confirm the listing is omitted; with this branch, confirm it is returned.
4. Verify a non-postal address search still uses the original full-value matching behavior and a configured radius search still uses its coordinate query.

Local verification:

- `php -l includes/model/Listings.php`
- Reflection-based address-query cases passed for reordered terms, comma-separated terms, single-term input, and a non-postal street address.
- A WordPress integration check created a temporary listing with `_address = 205 Route de Montricoux, 82800 Nègrepelisse`, confirmed the old full-string query omitted it, confirmed the new query returned it for `Nègrepelisse 82800`, and removed the temporary listing.
- All PHP files in the clean Directorist 8.9.4 package passed `php -l` after applying this patch.

Notes:

- The full-file PHPCS command remains non-zero because `includes/model/Listings.php` already contains four tab-indentation errors at lines 2668–2672 and existing warnings outside this focused change. No unrelated formatting was changed.
- The customer site was used only for read-only reproduction and was not modified.

## Any linked issues
- Support ticket: https://secure.helpscout.net/conversation/3427303087/6329?viewId=8936453

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
