### PR TITLE
Fix category assignments when CSV terms share names across taxonomies

### DIFF
--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -392,13 +392,8 @@ if ( ! class_exists( 'ATBDP_Tools' ) ) :
                         $multiple = count( $terms ) > 0;
 
                         foreach ( $terms as $term ) {
-                            $term = trim( $term );
-
-                            if ( isset( $terms_cache[ $term ] ) ) {
-                                $term_id = $terms_cache[ $term ];
-                            } else {
-                                $term_id = $this->maybe_create_term( $term, $taxonomy );
-                            }
+                            $term    = trim( $term );
+                            $term_id = $this->get_cached_term_id( $term, $taxonomy, $terms_cache );
 
                             if ( empty( $term_id ) ) {
                                 continue;
@@ -409,7 +404,6 @@ if ( ! class_exists( 'ATBDP_Tools' ) ) :
                             }
 
                             $term_ids[] = $term_id;
-                            $terms_cache[ $term ] = $term_id;
                         }
 
                         wp_set_object_terms( $post_id, $term_ids, $taxonomy, $multiple );
@@ -511,6 +505,32 @@ if ( ! class_exists( 'ATBDP_Tools' ) ) :
             $data['redirect_url'] = esc_url( admin_url( 'edit.php?post_type=at_biz_dir&page=tools&step=3' ) );
 
             wp_send_json( $data );
+        }
+
+        /**
+         * Get a taxonomy-specific term ID from the import cache.
+         *
+         * The same term name can exist in multiple taxonomies. Keeping each
+         * taxonomy in a separate cache prevents a tag ID from being reused as
+         * a category or location ID during the same import batch.
+         *
+         * @param string $term        Term name.
+         * @param string $taxonomy    Taxonomy name.
+         * @param array  $terms_cache Cached term IDs grouped by taxonomy.
+         * @return int|null Term ID.
+         */
+        public function get_cached_term_id( $term, $taxonomy, &$terms_cache ) {
+            if ( isset( $terms_cache[ $taxonomy ][ $term ] ) ) {
+                return $terms_cache[ $taxonomy ][ $term ];
+            }
+
+            $term_id = $this->maybe_create_term( $term, $taxonomy );
+
+            if ( ! empty( $term_id ) ) {
+                $terms_cache[ $taxonomy ][ $term ] = $term_id;
+            }
+
+            return $term_id;
         }
 
         /**

--- a/tests/php/listing-import-taxonomy-cache.php
+++ b/tests/php/listing-import-taxonomy-cache.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Regression test for taxonomy-specific listing import term caching.
+ *
+ * Run with: php tests/php/listing-import-taxonomy-cache.php
+ *
+ * @package Directorist
+ */
+
+require dirname( __DIR__, 2 ) . '/includes/classes/class-tools.php';
+
+/**
+ * Test double that creates deterministic term IDs per taxonomy.
+ */
+class Directorist_Import_Taxonomy_Cache_Test_Tools extends ATBDP_Tools {
+    /**
+     * Number of term lookups keyed by taxonomy and term name.
+     *
+     * @var array
+     */
+    public $term_lookups = [];
+
+    /**
+     * Skip the WordPress hook registrations in the parent constructor.
+     */
+    public function __construct() {}
+
+    /**
+     * Return a deterministic term ID for the requested taxonomy.
+     *
+     * @param string $term     Term name.
+     * @param string $taxonomy Taxonomy name.
+     * @return int Term ID.
+     */
+    public function maybe_create_term( $term, $taxonomy ) {
+        $key = $taxonomy . ':' . $term;
+
+        if ( ! isset( $this->term_lookups[ $key ] ) ) {
+            $this->term_lookups[ $key ] = 0;
+        }
+
+        ++$this->term_lookups[ $key ];
+
+        return 'at_biz_dir-tags' === $taxonomy ? 101 : 202;
+    }
+}
+
+/**
+ * Stop the test when an assertion fails.
+ *
+ * @param bool   $condition Assertion result.
+ * @param string $message   Failure message.
+ * @return void
+ */
+function directorist_import_cache_assert( $condition, $message ) {
+    if ( $condition ) {
+        return;
+    }
+
+    fwrite( STDERR, "FAIL: {$message}\n" );
+    exit( 1 );
+}
+
+$tools = new Directorist_Import_Taxonomy_Cache_Test_Tools();
+$cache = [];
+$term  = 'Power Wheelchairs';
+
+$tag_id      = $tools->get_cached_term_id( $term, 'at_biz_dir-tags', $cache );
+$category_id = $tools->get_cached_term_id( $term, 'at_biz_dir-category', $cache );
+$cached_tag  = $tools->get_cached_term_id( $term, 'at_biz_dir-tags', $cache );
+
+directorist_import_cache_assert( 101 === $tag_id, 'The tag term should use the tag taxonomy ID.' );
+directorist_import_cache_assert( 202 === $category_id, 'The category term should use the category taxonomy ID.' );
+directorist_import_cache_assert( $tag_id !== $category_id, 'Matching names in different taxonomies must not share a cached ID.' );
+directorist_import_cache_assert( $tag_id === $cached_tag, 'Repeated terms in one taxonomy should use the cached ID.' );
+directorist_import_cache_assert( 1 === $tools->term_lookups[ 'at_biz_dir-tags:' . $term ], 'The tag term should be resolved once.' );
+directorist_import_cache_assert( 1 === $tools->term_lookups[ 'at_biz_dir-category:' . $term ], 'The category term should be resolved once.' );
+
+echo "PASS: listing import term IDs are cached per taxonomy.\n";


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
CSV listing imports could silently omit category assignments when the same term name appeared in more than one mapped taxonomy, such as both `tag` and `category`. The importer cached term IDs only by term name, so a tag ID created first could be reused while processing the category taxonomy. WordPress rejected the mismatched term ID, while the listing itself continued importing successfully.

This change scopes the import term cache by taxonomy and term name. Matching labels in tags, categories, and locations now resolve and reuse their own taxonomy-specific IDs. A focused regression test covers the shared-name case and confirms that repeated terms within one taxonomy still use the cache.

How to reproduce the issue or test the changes:

1. Prepare a listing CSV with `tag` before `category` and use the same value, such as `Power Wheelchairs`, in both columns.
2. On the base branch, import the CSV and observe that the listing is created but the category assignment is missing.
3. Check out this change, import the same CSV, and verify that both the tag and category are assigned.
4. Import multiple rows with the repeated shared value and verify that each taxonomy retains the correct term ID without duplicate lookups.

Local verification:

- `php -l includes/classes/class-tools.php`
- `php -l tests/php/listing-import-taxonomy-cache.php`
- `php tests/php/listing-import-taxonomy-cache.php`
- `php tests/php/listing-taxonomy-subterms.php`
- `git diff --check`

Notes:

- Targeted PHPCS completed with no errors after suppressing a PHP 8.5 deprecation from the repository's WordPressCS 2.3 dependency. It still reports 13 pre-existing warnings in `includes/classes/class-tools.php`; the new regression test reports no violations.
- No client site was modified. The supplied client-site access points to a different directory dataset, so live import verification was intentionally not performed there.

## Any linked issues
- Help Scout: https://secure.helpscout.net/conversation/3439909615/6571

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)

## Files changed

- `includes/classes/class-tools.php` — cache imported term IDs separately for each taxonomy before assigning them to listings.
- `tests/php/listing-import-taxonomy-cache.php` — verify identical tag and category names receive distinct cached term IDs while repeated same-taxonomy lookups remain cached.
