### PR TITLE
Fix multi-directory listing export columns

### DIFF
--- a/includes/classes/class-listings-export.php
+++ b/includes/classes/class-listings-export.php
@@ -170,16 +170,31 @@ class Listings_Exporter {
         if ( ! is_array( $data_table ) ) {
             return $data_table; }
 
-        $max_tr_val   = max( $tr_lengths );
-        $max_tr_index = array_search( $max_tr_val, $tr_lengths );
-        $modal_tr     = $data_table[ $max_tr_index ];
+        $columns = [];
+        foreach ( $data_table as $row ) {
+            if ( ! is_array( $row ) ) {
+                continue;
+            }
+
+            foreach ( array_keys( $row ) as $row_key ) {
+                $columns[ $row_key ] = '';
+            }
+        }
+
+        if ( empty( $columns ) ) {
+            return $data_table;
+        }
 
         $justify_table = [];
         foreach ( $data_table as $row ) {
+            if ( ! is_array( $row ) ) {
+                continue;
+            }
+
             $tr = [];
 
-            foreach ( $modal_tr as $row_key => $row_value ) {
-                $tr[ $row_key ] = ( isset( $row[ $row_key ] ) ) ? $row[ $row_key ] : '';
+            foreach ( $columns as $row_key => $default_value ) {
+                $tr[ $row_key ] = array_key_exists( $row_key, $row ) ? $row[ $row_key ] : $default_value;
             }
 
             $justify_table[] = $tr;

--- a/tests/php/listings-export-multi-directory-columns.php
+++ b/tests/php/listings-export-multi-directory-columns.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Regression test for multi-directory listing export columns.
+ *
+ * Run with: php tests/php/listings-export-multi-directory-columns.php
+ *
+ * @package Directorist
+ */
+
+require dirname( __DIR__, 2 ) . '/includes/classes/class-listings-export.php';
+
+/**
+ * Stop the test when an assertion fails.
+ *
+ * @param bool   $condition Assertion result.
+ * @param string $message   Failure message.
+ * @return void
+ */
+function directorist_export_test_assert( $condition, $message ) {
+    if ( $condition ) {
+        return;
+    }
+
+    fwrite( STDERR, "FAIL: {$message}\n" );
+    exit( 1 );
+}
+
+$rows = [
+    [
+        'id'            => 101,
+        'directory'     => 'directory-one',
+        'custom-number' => '5000',
+    ],
+    [
+        'id'              => 202,
+        'directory'       => 'directory-two',
+        'price'           => '3500',
+        'custom-checkbox' => null,
+    ],
+    [
+        'id'                => 303,
+        'directory'         => 'directory-three',
+        'custom-date'       => '2027-08-27',
+        'custom-date-2'     => '2027-08-29',
+        'address'           => 'Example City',
+        'hide_map'          => '',
+        'manual_lat'        => '44.2600',
+        'manual_lng'        => '12.3500',
+        'custom-checkbox-2' => 'Famiglie',
+    ],
+];
+
+$expected_columns = [
+    'id',
+    'directory',
+    'custom-number',
+    'price',
+    'custom-checkbox',
+    'custom-date',
+    'custom-date-2',
+    'address',
+    'hide_map',
+    'manual_lat',
+    'manual_lng',
+    'custom-checkbox-2',
+];
+
+$justified_rows = Directorist\Listings_Exporter::justifyDataTableRow(
+    $rows,
+    array_map( 'count', $rows )
+);
+
+foreach ( $justified_rows as $row ) {
+    directorist_export_test_assert(
+        $expected_columns === array_keys( $row ),
+        'Every exported row should contain the union of fields from all directories.'
+    );
+}
+
+directorist_export_test_assert(
+    null === $justified_rows[1]['custom-checkbox'],
+    'An existing null value should not be replaced by the default empty string.'
+);
+
+directorist_export_test_assert(
+    '' === $justified_rows[0]['custom-date'],
+    'A field unavailable to a directory should be exported as an empty value.'
+);
+
+echo "PASS: multi-directory export preserves every directory column.\n";


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Listing CSV exports can omit fields when listings belong to directory types with different submission-form schemas. The exporter currently chooses the row with the largest field count as the template for every row, so a field unique to any other directory never reaches the CSV header or output.

This change builds an ordered union of field keys across all listing rows, then normalizes every row against that complete column set. Existing null values are preserved with `array_key_exists()`, while fields unavailable to a listing remain empty. A standalone regression test covers three directory schemas with unique custom, pricing, date, address, and map columns.

How to reproduce the issue or test the changes:

1. Create at least two directory types with different submission-form fields and publish a listing in each type.
2. Export the listings to CSV and compare the header with the combined fields configured across the directory types.
3. Verify that every configured export field appears once in first-seen order, every row has the same columns, unavailable fields are empty, and existing null values remain null before CSV serialization.

Local verification:

- `php -l includes/classes/class-listings-export.php`
- `php -l tests/php/listings-export-multi-directory-columns.php`
- `php tests/php/listings-export-multi-directory-columns.php`
- `php -d error_reporting=8191 vendor/bin/phpcs --standard=phpcs.xml --warning-severity=0 includes/classes/class-listings-export.php tests/php/listings-export-multi-directory-columns.php`

Notes:

- The default PHPCS invocation on local PHP 8.5 reports an internal deprecation exception from WordPress Coding Standards 2.3.0. Running the same targeted ruleset with third-party deprecation notices suppressed passes; repository CI uses PHP 7.4.
- PR #2987 contains the same core correction but also includes unrelated formatting changes and no automated regression test. Its PHPCS job failed at checkout before inspecting the code.

## Any linked issues
- TeamSync: https://team.sovware.com/support/directorist/3270
- Help Scout: https://secure.helpscout.net/conversation/3427185786/6326?viewId=8936453
- GitHub: https://github.com/sovware/directorist/pull/2987

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
